### PR TITLE
docker-storage-setup: Skip block zeroing in thin pool

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -90,7 +90,7 @@ setup_lvm_data_meta_mode () {
 }
 
 create_lvm_thin_pool () {
-  lvconvert -y --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
+  lvconvert -y --zero n --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
   if [ $? -ne 0 ];then
     echo "Converting $VG/docker-data and $VG/docker-meta to LVM thin pool failed. Exiting."
     exit 1


### PR DESCRIPTION
This fixes issue #10 

By default docker sets up a thin pool where block zeroing is skipped. This
script basically sets up a pool for docker, so use same behavior.

In general thin pool folks have recommended using skip block zeroing. 

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>