### PR TITLE
docker-storage-setup: Disable auto extension of data logical volume

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -364,8 +364,6 @@ if [ -n "$DATA_LV_SIZE" ]; then
     else
       lvextend -L $DATA_SIZE $VG/$DATA_LV_NAME || true
     fi
-  else
-    lvextend -l "+$DEFAULT_DATA_SIZE_PERCENT%FREE" $VG/$DATA_LV_NAME || true
   fi
 elif [ -n "$DATA_SIZE" ]; then
   # TODO: Error handling when DATA_SIZE > available space.

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -335,18 +335,8 @@ for LV in $LV_DATA; do
 done
 IFS=$SAVEDIFS
 
-# NB:  The code below all becomes very strange when you consider
-# the case of a reboot.  If the config file is using "%FREE" specifications,
-# it will grow on each reboot until the VG is full.
-
 META_SIZE=$(( $VG_SIZE / 1000 + 1 ))
-if [ -n "$META_LV_SIZE" ]; then
-  if [ "$META_LV_SIZE" -lt "$META_SIZE" ]; then
-    # Keep this nonfatal, since we already have a metadata LV
-    # of _some_ size
-    lvextend -L ${META_SIZE}s $VG/$META_LV_NAME || true
-  fi
-else
+if [ ! -n "$META_LV_SIZE" ]; then
   lvcreate -L ${META_SIZE}s -n $META_LV_NAME $VG
 fi
 


### PR DESCRIPTION
Fixes issue #13 

Right now docker-storage-setup keeps on extending the size of data volume
as long as there is free space in the pool. So even if a user has left
some space in the pool free for metadata volume extension, that free space
will be consumed by data volume extension.

Now lvm2 has nice capabilities to automatically extend pool (both data and
metadata) when pool is running short on space. Following are two knobs which
one can use for auto extension.

thin_pool_autoextend_threshold = 100
thin_pool_autoextend_percent = 20

By default extension is disabled. One needs to enable it manually by chaning
the value of thin_pool_autoextend_threshold.

In general it is a good idea to know consume all the free pool space until
and use mechanism like extending pool by certain percentage when it hits
threshold. That allows free space in volume group to be shared by other
entities like root which might have to be grown on need basis too.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>