### PR TITLE
docker-storage-setup: Do not overwrite /etc/sysconfig/docker-storage always

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -131,6 +131,7 @@ extend_data_lv () {
 setup_lvm_thin_pool () {
   if ! lvm_pool_exists; then
     create_lvm_thin_pool
+    write_storage_config_file
   else
     extend_data_lv
   fi
@@ -274,4 +275,3 @@ fi
 
 # Set up lvm thin pool LV
 setup_lvm_thin_pool
-write_storage_config_file


### PR DESCRIPTION
This fixes issue #16 

Right now upon each run of script, we overwrite /etc/sysconfig/docker-storage
and this could be bad if user added some of his own storage options. These
will be lost over next run of script.

Write /etc/sysconfig/docker-storage only when pool is created. After that
leave it untouched.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>