### PR TITLE
docker-storage-setup: Create a default config file to be shipped with pkg

### DIFF
--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -1,0 +1,25 @@
+# A quoted, space-separated list of devices to be used.  This currently
+# expects the devices to be unpartitioned drives.  If "VG" is not specified,
+# then use of the root disk's extra space is implied.
+#
+# DEVS=/dev/vdb
+
+# The volume group to use for docker storage.  Defaults to the
+# volume group where the root filesystem resides.  If VG is specified and the
+# volume group does not exist, it will be created (which requires that "DEVS"
+# be nonempty, since we don't currently support putting a second partition on
+# the root disk).
+#
+# VG=
+
+# The size to which the root filesystem should be grown.
+# Value should be acceptable to -L option of lvextend.
+#
+# ROOT_SIZE=8G
+
+# The desired size for the docker data LV.  Defaults to using all free space
+# in the VG after the root LV and docker metadata LV have been
+# allocated/grown.
+# Value should be acceptable to -L option of lvextend.
+#
+# DATA_SIZE=8G

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -7,6 +7,7 @@ License:        ASL 2.0
 URL:            http://github.com/a13m/docker-storage-setup/
 Source0:        docker-storage-setup.sh
 Source1:        docker-storage-setup.service
+Source2:        docker-storage-setup.conf
 
 BuildRequires:  pkgconfig(systemd)
 
@@ -28,8 +29,8 @@ install -d %{buildroot}%{_bindir}
 install -p -m 755 %{SOURCE0} %{buildroot}%{_bindir}/docker-storage-setup
 install -d %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
-# install -d %{buildroot}%{_sysconfdir}/sysconfig/
-# install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
+install -d %{buildroot}%{_sysconfdir}/sysconfig/
+install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
 
 %post
 %systemd_post %{name}.service
@@ -43,7 +44,7 @@ install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
 %files
 %{_unitdir}/docker-storage-setup.service
 %{_bindir}/docker-storage-setup
-# %{_sysconfdir}/sysconfig/docker-storage-setup
+%config(noreplace) %{_sysconfdir}/sysconfig/docker-storage-setup
 
 %changelog
 * Thu Oct 16 2014 Andy Grimm <agrimm@redhat.com> - 0.0.1-2


### PR DESCRIPTION
Fixes issue #18 

I think sending a documented default config file with the package makes it
easy to configure and makes it easy to more config options down the line,
like chunk size of thin pool.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>