### PR TITLE
Atomically update config file

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -77,9 +77,10 @@ write_storage_config_file () {
     done )
 
   storage_options="DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=$POOL_DEVICE_PATH"
-cat <<EOF > $DOCKER_STORAGE
+cat <<EOF > $DOCKER_STORAGE.tmp
 $storage_options
 EOF
+  mv $DOCKER_STORAGE.tmp $DOCKER_STORAGE
 }
 
 create_metadata_lv() {


### PR DESCRIPTION
Just noticed this while reviewing another PR; previously if we got
e.g. ENOSPC or something on startup, we'd leave a broken partially
written file.  Do the tempfile + `rename()` dance.