### PR TITLE
Disable auto data volume extension when DATA_SIZE is specified

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -36,8 +36,15 @@ The options below should be specified as values acceptable to 'lvextend -L':
 ROOT_SIZE: The size to which the root filesystem should be grown.
 
 DATA_SIZE: The desired size for the docker data LV.  Defaults to using
-           all free space in the VG after the root LV and docker
+           98% free space in the VG after the root LV and docker
            metadata LV have been allocated/grown.
+
+           DATA_SIZE can take values acceptable to "lvcreate -L" as
+           well as some values acceptable to to "lvcreate -l". If user
+           intends to pass values acceptable to "lvcreate -l", then
+           only those values which contains "%" in syntax are
+           acceptable.  If value does not contain "%" it is assumed
+           value is suitable for "lvcreate -L".
 
 
 \f[B]Sample\f[]

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -115,26 +115,10 @@ create_lvm_thin_pool () {
   lvconvert -y --zero n --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
 }
 
-# If user specified DATA_SIZE and current pool is smaller, extend it.
-extend_data_lv () {
-  # TODO: Figure out failure cases other than when the requested
-  # size is larger than the current size.  For now, we just let
-  # lvextend fail.
-  if [ -n "$DATA_SIZE" ]; then
-    if [[ $DATA_SIZE == *%* ]]; then
-      lvextend -l $DATA_SIZE $VG/$DATA_LV_NAME || true
-    else
-      lvextend -L $DATA_SIZE $VG/$DATA_LV_NAME || true
-    fi
-  fi
-}
-
 setup_lvm_thin_pool () {
   if ! lvm_pool_exists; then
     create_lvm_thin_pool
     write_storage_config_file
-  else
-    extend_data_lv
   fi
 }
 


### PR DESCRIPTION
Fixes issue #21   

  If DATA_SIZE is specified we will auto grow data volume if there is free
    space in pool. Say DATA_SIZE=+80%FREE, then we will automatically consume
    80% of free space in volume group upon restart of service.
    
    If user did not specify DATA_SIZE, then by default script determines data
    volume size to be 98% of free space in volume group. And we got rid of that
    logic to auto extend. This is very similar, difference is that was default
    and this is user specified.
    
    Now if we are moving towrads relying on lvm to auto grow pool based on
    /etc/lvm/lvm.conf settings, then we don't require this.
    
    Also it will make life little easier in some cases where this behavior is
    unexected. For example, assume root volume group is 500G in size and I
    want to use only 50% of free space then one can speicfy DATA_SIZE=50%FREE.
    Now one does not expect that if later volume group grows then we will
    extend data volume to make sure it meets 50% of FREE at that time.
    
    So IOW, there could be use cases for both. I am inclined towards not growing
    data volume automatically as lvm2 already has mechanism to do that. So we
    don't have to replicate that thing in docker-storage-setup. If lvm2 does
    not work well for some reason, then we can revisit introducing auto growth
    of data volume based on some config optoin, say AUTO_GROW=1.
    
    For now, get rid of auto growth of data volume logic. This means that
    DATA_SIZE value will take effect only during pool creation time. If pool
    has been created and user changes DATA_SIZE, it will not have any effect
    when service restarts. So this might be a little behavior change for
    existing users of DATA_SIZE. They will have to rely on lvm2 for auto
    data volume extension.
