### PR TITLE
Disable growpart logic by default

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -35,6 +35,12 @@ VG:   The volume group to use for docker storage.  Defaults to the
       lvm2 version should be same or higher than lvm2-2.02.112 for lvm
       thin pool functionality to work properly.
 
+GROWPART:
+      One can use this option to enable/disable growing of partition
+      table backing root volume group. This is intended for virtualization
+      and cloud installations. By default it is disabled. Use GROWPART=true
+      to enable automatic partition table resizing.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -10,7 +10,11 @@ docker\-storage\-setup - Grows the root filesystem and sets up a LVM thin pool f
 None. 
 .SH EXAMPLES
 Run \f[B]docker-storage-setup\f[] after setting up your configuration in 
-/etc/sysconfig/docker-storage-setup. 
+/etc/sysconfig/docker-storage-setup. One can look at
+/usr/lib/docker-storage-setup/docker-storage-setup for various options and
+their default settings. Anything user wants to change, should be changed
+in /etc/sysconfig/docker-storage-setup. This is the file which will
+override any settings specified in /usr/lib/docker-storage-setup/docker-storage-setup.
 
 lvm2 version should be same or higher than lvm2-2.02.112 for lvm thin pool
 functionality to work properly.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -23,3 +23,8 @@
 # Value should be acceptable to -L option of lvextend.
 #
 # DATA_SIZE=8G
+
+# Enable resizing partition table backing root volume group. By default it
+# is disabled until and unless GROWPART=true is specified.
+#
+GROWPART=false

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -158,6 +158,8 @@ is_old_data_meta_mode() {
 }
 
 grow_root_pvs() {
+  [ -x "/usr/bin/growpart" ] || return
+
   # Note that growpart is only variable here because we may someday support
   # using separate partitions on the same disk.  Today we fail early in that
   # case.  Also note that the way we are doing this, it should support LVM

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -214,6 +214,12 @@ create_extend_volume_group() {
 }
 
 # Main Script
+if [ -e /usr/lib/docker-storage-setup/docker-storage-setup ]; then
+  source /usr/lib/docker-storage-setup/docker-storage-setup
+fi
+
+# If user has overridden any settings in /etc/sysconfig/docker-storage-setup
+# take that into account.
 if [ -e /etc/sysconfig/docker-storage-setup ]; then
   source /etc/sysconfig/docker-storage-setup
 fi

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -160,6 +160,9 @@ is_old_data_meta_mode() {
 grow_root_pvs() {
   [ -x "/usr/bin/growpart" ] || return
 
+  # Grow root pvs only if user asked for it through config file.
+  [ "$GROWPART" != "true" ] && return
+
   # Note that growpart is only variable here because we may someday support
   # using separate partitions on the same disk.  Today we fail early in that
   # case.  Also note that the way we are doing this, it should support LVM

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -12,7 +12,6 @@ Source2:        docker-storage-setup.conf
 BuildRequires:  pkgconfig(systemd)
 
 Requires:       lvm2
-Requires:       cloud-utils-growpart
 Requires:       systemd-units
 Requires:       xfsprogs 
 

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -28,8 +28,8 @@ install -d %{buildroot}%{_bindir}
 install -p -m 755 %{SOURCE0} %{buildroot}%{_bindir}/docker-storage-setup
 install -d %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
-install -d %{buildroot}%{_sysconfdir}/sysconfig/
-install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
+install -d %{buildroot}%{_libdir}/docker-storage-setup/
+install -p -m 644 %{SOURCE2} %{buildroot}%{_libdir}/docker-storage-setup/docker-storage-setup
 
 %post
 %systemd_post %{name}.service
@@ -43,7 +43,7 @@ install -p -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage
 %files
 %{_unitdir}/docker-storage-setup.service
 %{_bindir}/docker-storage-setup
-%config(noreplace) %{_sysconfdir}/sysconfig/docker-storage-setup
+%{_libdir}/docker-storage-setup/docker-storage-setup
 
 %changelog
 * Thu Oct 16 2014 Andy Grimm <agrimm@redhat.com> - 0.0.1-2


### PR DESCRIPTION
Fixes #24 

This is generic cleanup related to growpart utility and logic around it. I think for project atomic one shall have to take care of two things.

- Make sure that cloud-utils-growpart gets installed. Installing docker-storage-setup will not pull it in automatically.

- Make sure to modify GROWPART= variable in /etc/sysconfig/docker-storage-setup to enable automatic growing of root pvs each reboot.