### PR TITLE
docker-storage-setup: Enforce storage driver to be devicemapper

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -76,7 +76,7 @@ write_storage_config_file () {
     fi
     done )
 
-  storage_options="DOCKER_STORAGE_OPTIONS=--storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=$POOL_DEVICE_PATH"
+  storage_options="DOCKER_STORAGE_OPTIONS=-s devicemapper --storage-opt dm.fs=xfs --storage-opt dm.thinpooldev=$POOL_DEVICE_PATH"
 cat <<EOF > $DOCKER_STORAGE.tmp
 $storage_options
 EOF


### PR DESCRIPTION
Fixes issue #26 

Right now docker-storage-setup creates storage options which are valid
only for devicemapper driver. If some other driver is trying to initialize
and it is not properly written it will return error saying unrecognized
options dm.fs etc.

I am running into this issue now. Recently upstream has added zfs as
graphdriver and that takes precedence over devicemapper. And that driver
is returning error that dm.fs is unrecognized option.

Given that docker-storage-setup is expecting docker to use devicemapper
graphdriver and generating options which only work with devicemapper,
it makes sense to enforce the driver to use here to avoid errors.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>