### PR TITLE
docker-storage-setup: Enable automatic pool extension using lvm facil…

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -41,6 +41,21 @@ GROWPART:
       and cloud installations. By default it is disabled. Use GROWPART=true
       to enable automatic partition table resizing.
 
+AUTO_EXTEND_POOL:
+      Enable automatic extension of pool by lvm. lvm can monitor
+      the pool and automatically extend it when pool is getting full.
+
+POOL_AUTOEXTEND_THRESHOLD:
+      Determines the pool extension threshold in terms of percentage
+      of pool size. For example, if threhold is 60, that means when
+      pool is 60% full, threshold has been hit.
+
+POOL_AUTOEXTEND_PERCENT:
+      Determines the amount by which pool needs to be grown. This is
+      specified in terms of % of pool size. So a value of 20 means
+      that when threhold is hit, pool will be grown by 20% of existing
+      pool size.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -28,3 +28,12 @@
 # is disabled until and unless GROWPART=true is specified.
 #
 GROWPART=false
+
+# Enable/disable automatic pool extension using lvm
+AUTO_EXTEND_POOL=yes
+
+# Auto pool extension threshold (in % of pool size)
+POOL_AUTOEXTEND_THRESHOLD=60
+
+# Extend the pool by specified percentage when threshold is hit.
+POOL_AUTOEXTEND_PERCENT=20


### PR DESCRIPTION
…ities

Fixes #29 

Enable automatic pool extension. Provide knobs to disbale this behavior. Also
provide knobs to control when pool should be extended by how much.

I am using lvm profile and attaching that profile to docker thin pool. That
means these settings don't enable pool extension globally in the system and
these settings only apply to docker thin pool.

Pool extension is enabled by default. That way one can even start small
both interms of data and meatadata volumes and these will be grown
automatically.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>