### PR TITLE
docker-storage-setup: Reserve 60% of free space for data volume

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -61,7 +61,7 @@ The options below should be specified as values acceptable to 'lvextend -L':
 ROOT_SIZE: The size to which the root filesystem should be grown.
 
 DATA_SIZE: The desired size for the docker data LV.  Defaults to using
-           98% free space in the VG after the root LV and docker
+           60% free space in the VG after the root LV and docker
            metadata LV have been allocated/grown.
 
            DATA_SIZE can take values acceptable to "lvcreate -L" as

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -17,12 +17,16 @@
 #
 # ROOT_SIZE=8G
 
-# The desired size for the docker data LV.  Defaults to using all free space
-# in the VG after the root LV and docker metadata LV have been
-# allocated/grown.
-# Value should be acceptable to -L option of lvextend.
+# The desired size for the docker data LV.  It defaults using 60% of all
+# free space.
 #
-# DATA_SIZE=8G
+# DATA_SIZE can take values acceptable to "lvcreate -L" as well as some
+# values acceptable to to "lvcreate -l". If user intends to pass values
+# acceptable to "lvcreate -l", then only those values which contains "%"
+# in syntax are acceptable.  If value does not contain "%" it is assumed
+# value is suitable for "lvcreate -L".
+#
+DATA_SIZE=60%FREE
 
 # Enable resizing partition table backing root volume group. By default it
 # is disabled until and unless GROWPART=true is specified.


### PR DESCRIPTION
Fixes #32 

Right now by default we reserve 98% of free space as data volume. Now we
have enabled automatic pool extension logic. That will make sure that pool
data and metadata volumes will grow automatically as they start filling up.

This means we don't have to consume all the free space available at startup.
It can be consumed dynamically. One advantage of not consuming all the space
up front is that it can be used for some other purpose. For example, one
can try to grow root volume. 3G of root might not be sufficient.

Leaving free space also allows for extension of metadata volume later easily.
Some openshift folks complained that not enough metadata size is being
reserved at startup time. Leaving space free and growing volumes dynamically
gives us lot of flexibility here for different kind of workloads.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>