### PR TITLE
docker-storage-setup: Use chunk size 512K by default

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -56,6 +56,10 @@ POOL_AUTOEXTEND_PERCENT:
       that when threhold is hit, pool will be grown by 20% of existing
       pool size.
 
+CHUNK_SIZE:
+      Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
+      be suitable to be passed to --chunk-size option of lvconvert.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -28,6 +28,11 @@
 #
 DATA_SIZE=60%FREE
 
+# Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
+# be suitable to be passed to --chunk-size option of lvconvert.
+#
+CHUNK_SIZE=512K
+
 # Enable resizing partition table backing root volume group. By default it
 # is disabled until and unless GROWPART=true is specified.
 #

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -107,7 +107,10 @@ create_lvm_thin_pool () {
   create_metadata_lv
   create_data_lv
 
-  lvconvert -y --zero n --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
+  if [ -n "$CHUNK_SIZE" ]; then
+    CHUNK_SIZE_ARG="-c $CHUNK_SIZE"
+  fi
+  lvconvert -y --zero n $CHUNK_SIZE_ARG --thinpool $VG/$DATA_LV_NAME --poolmetadata $VG/$META_LV_NAME
 }
 
 setup_lvm_thin_pool () {


### PR DESCRIPTION
Fixes #31 and #23 

This patch does two things.

- Provides a knob CHUNK_SIZE to allow controlling chunk size of thin pool.
- Switches to default chunk size of 512K instead of 64K default of lvm.

Setting a chunk size is very tricky. larger chunk size can help in reducing
metadata usage and fragmentation. But at the same time consume more disk
space.

This chunk size has been arrived based on jeremy's testing and recommendation
from thin pool developers.

In case this does not work well, we can always change default.
 
Signed-off-by: Vivek Goyal <vgoyal@redhat.com>