### PR TITLE
Create temporary files in /tmp, not cwd

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -222,7 +222,7 @@ enable_auto_pool_extension() {
   local profileName="${volume_group}--${pool_volume}-extend"
   local profileFile="${profileName}.profile"
   local profileDir
-  local tmpFile=`mktemp tmp.XXXXX`
+  local tmpFile=`mktemp -t tmp.XXXXX`
 
   profileDir=$(lvm dumpconfig | grep "profile_dir" | cut -d "=" -f2 | sed 's/"//g')
   [ -n "$profileDir" ] || return 1


### PR DESCRIPTION
Otherwise we end up polluting `/` on a mainline system, and on Atomic
it will fail.