### PR TITLE
docker-storage-setup: If metadata volume already exists, do not create new one

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -78,6 +78,16 @@ EOF
 }
 
 create_metadata_lv() {
+  # If metadata lvm already exists (failures from previous run), then
+  # don't create it.
+  # TODO: Modify script to cleanup meta and data lvs if failure happened
+  # later. Don't exit with error leaving partially created lvs behind.
+
+  if lvs -a $VG/${META_LV_NAME} --noheadings &>/dev/null; then
+        echo "Metadata volume $META_LV_NAME already exists. Not creating a new one."
+	return 0
+  fi
+
   # Reserve 0.1% of the free space in the VG for docker metadata.
   # Calculating the based on actual data size might be better, but is
   # more difficult do to the range of possible inputs.


### PR DESCRIPTION
Fixes #39 

It can happen that we created a metadata volume and later there was not
enough space to create data volume and script exited, leaving behind
metadata volume. Later if user adds more space to volume group and re-runs
the script, it fails saying metadata volume already exists.

For now fix this by checking if metadata volume exists or not. If it exists
use it (instead of erroring out).

I think ideally we should have cleanup logic and cleanup any logical
volumes created if error happens later. That probably also means
getting rid of "set -e".

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>