### PR TITLE
Grow root filesystem when growing LV

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -353,7 +353,7 @@ grow_root_pvs
 
 if [ -n "$ROOT_SIZE" ]; then
   # TODO: Error checking if specified size is <= current size
-  lvextend -L $ROOT_SIZE $ROOT_DEV || true
+  lvextend -r -L $ROOT_SIZE $ROOT_DEV || true
 fi
 
 # Set up lvm thin pool LV


### PR DESCRIPTION
When one allocates more space, one expects to be able to use it.

Closes #7