### PR TITLE
docker-storage-setup: Add an option -h for help message

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -4,10 +4,12 @@
 docker\-storage\-setup - Grows the root filesystem and sets up storage for docker.
 .SH SYNOPSIS
 .PP
-\f[B]docker-storage-setup\f[] 
+\f[B]docker-storage-setup\f[] [OPTIONS]
 .SH OPTIONS
 .PP
-None. 
+\f[B]-h, --help\f[]
+  Print usage statement
+
 .SH EXAMPLES
 Run \f[B]docker-storage-setup\f[] after setting up your configuration in 
 /etc/sysconfig/docker-storage-setup. One can look at

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -445,7 +445,22 @@ setup_storage() {
   fi
 }
 
+usage() {
+  echo "Usage: $1 [OPTIONS]"
+  echo
+  echo "Grows the root filesystem and sets up storage for docker."
+  echo
+  echo "Options:"
+  echo "  -h, --help		Print help message."
+}
+
 # Main Script
+
+if [ $# -gt 0 ]; then
+  usage $0
+  exit 0
+fi
+
 if [ -e /usr/lib/docker-storage-setup/docker-storage-setup ]; then
   source /usr/lib/docker-storage-setup/docker-storage-setup
 fi


### PR DESCRIPTION
Fixes #51 
Add an option -h to display help message. Somebody got surprised when they
typed "docker-storage-setup -h" and it went ahead and setup the storage.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>