### PR TITLE
Enables pvcreate to assume "yes" on all questions and not to wait on user confirmation in order to proceed 

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -155,9 +155,9 @@ create_data_lv() {
 
   # TODO: Error handling when DATA_SIZE > available space.
   if [[ $DATA_SIZE == *%* ]]; then
-    lvcreate -l $DATA_SIZE -n $DATA_LV_NAME $VG
+    lvcreate -y -l $DATA_SIZE -n $DATA_LV_NAME $VG
   else
-    lvcreate -L $DATA_SIZE -n $DATA_LV_NAME $VG
+    lvcreate -y -L $DATA_SIZE -n $DATA_LV_NAME $VG
   fi
 }
 
@@ -281,7 +281,7 @@ unit: sectors
 
 ${dev}1 : start=     2048, size=  ${size}, Id=8e
 EOF
-    pvcreate ${dev}1
+    pvcreate -y ${dev}1
     PVS="$PVS ${dev}1"
   done
 }

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -155,9 +155,9 @@ create_data_lv() {
 
   # TODO: Error handling when DATA_SIZE > available space.
   if [[ $DATA_SIZE == *%* ]]; then
-    lvcreate -y -l $DATA_SIZE -n $DATA_LV_NAME $VG
+    lvcreate -l $DATA_SIZE -n $DATA_LV_NAME $VG
   else
-    lvcreate -y -L $DATA_SIZE -n $DATA_LV_NAME $VG
+    lvcreate -L $DATA_SIZE -n $DATA_LV_NAME $VG
   fi
 }
 


### PR DESCRIPTION
If there is file system signature on device then pvcreate will prompt user to confirm to wipe FS signature. When this happens, d-s-s will silently ignore this,and will not create desired storage backend ( in this case thin lvm  ) and will start docker using loop lvm storage configuration. 
d-s-s at time only checks if there is/are partition(s) on device(s) we specify in "DEVS" section. Device can have ( due to usage of device for file system sometimes before ) file system signature - even there is not any partition on it. 

This PR enables pvcreate to assume "yes" on all questions during pvcreate step.