### PR TITLE
docker-storage-setup: Use option -y for lvcreate

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -143,7 +143,7 @@ create_metadata_lv() {
   VG_SIZE=$( vgs --noheadings --nosuffix --units s -o vg_size $VG )
   META_SIZE=$(( $VG_SIZE / 1000 + 1 ))
   if [ ! -n "$META_LV_SIZE" ]; then
-    lvcreate -L ${META_SIZE}s -n $META_LV_NAME $VG
+    lvcreate -y -L ${META_SIZE}s -n $META_LV_NAME $VG
   fi
 }
 
@@ -155,9 +155,9 @@ create_data_lv() {
 
   # TODO: Error handling when DATA_SIZE > available space.
   if [[ $DATA_SIZE == *%* ]]; then
-    lvcreate -l $DATA_SIZE -n $DATA_LV_NAME $VG
+    lvcreate -y -l $DATA_SIZE -n $DATA_LV_NAME $VG
   else
-    lvcreate -L $DATA_SIZE -n $DATA_LV_NAME $VG
+    lvcreate -y -L $DATA_SIZE -n $DATA_LV_NAME $VG
   fi
 }
 


### PR DESCRIPTION
Fixes issue #56 

lvcreate creates data and metadata volumes before they are converted in
thin pool volume. If lvcreate finds an existing signature, it asks the
question whether to wipe it or not. As we run as a service by default
answer is no. But that signature gets wiped out anyway. Reason being
that lvcreate zeroes first 4K of logical volume and as part of that
zeroing any signatures in first 4K will get wiped out.

IOW, as of now, it does not matter what's the answer. We are wiping out
signatures by default during lvcreate.

And there are following messages on console.

docker-storage-setup[3240]: WARNING: xfs signature detected on /dev/rhel/docker-pool at offset 0. Wipe it? [y/n]: n
docker-storage-setup[3240]: Aborted wiping of xfs.
docker-storage-setup[3240]: 1 existing signature left on the device.
docker-storage-setup[3240]: Logical volume "docker-pool" created.

We really don't seem to have a need to preserve signatures. At pvcreate,
time we can make sure that disk already does not have any data on it. Once
it has been added to volume group, I guess we don't have to worry about
signatures existing and we can wipe it by default.

So let us use "-y" for lvcreate. This should kill those messages which
ask the question and wipe signatures anyway and give explicit messages that
signatures are being wiped. Atleast there will be less confusion and we know
that by default we will wipe signature during lvcreate.

Following are the messages after this change.

  Wiping xfs signature on /dev/fedora/docker-pool.
  Logical volume "docker-pool" created.

If something blows up, we can revisit it again.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>