### PR TITLE
docker-storage-setup: Ship an empty /etc/sysconfig/docker-storage-set…

### DIFF
--- a/docker-storage-setup-override.conf
+++ b/docker-storage-setup-override.conf
@@ -1,0 +1,4 @@
+# Edit this file to override any configuration options specified in
+# /usr/lib/docker-storage-setup/docker-storage-setup.
+#
+# For more details refer to "man docker-storage-setup"

--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -10,6 +10,7 @@ URL:            http://github.com/a13m/docker-storage-setup/
 Source0:        docker-storage-setup.sh
 Source1:        docker-storage-setup.service
 Source2:        docker-storage-setup.conf
+Source3:        docker-storage-setup-override.conf
 
 BuildRequires:  pkgconfig(systemd)
 
@@ -33,6 +34,8 @@ install -d %{buildroot}%{_unitdir}
 install -p -m 644 %{SOURCE1} %{buildroot}%{_unitdir}
 install -d %{buildroot}/%{dsslibdir}
 install -p -m 644 %{SOURCE2} %{buildroot}/%{dsslibdir}/docker-storage-setup
+install -d %{buildroot}%{_sysconfdir}/sysconfig/
+install -p -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
 
 %post
 %systemd_post %{name}.service
@@ -47,6 +50,7 @@ install -p -m 644 %{SOURCE2} %{buildroot}/%{dsslibdir}/docker-storage-setup
 %{_unitdir}/docker-storage-setup.service
 %{_bindir}/docker-storage-setup
 %{dsslibdir}/docker-storage-setup
+%config(noreplace) %{_sysconfdir}/sysconfig/docker-storage-setup
 
 %changelog
 * Thu Oct 16 2014 Andy Grimm <agrimm@redhat.com> - 0.0.1-2


### PR DESCRIPTION
…up file

Fixes issue #55 

Jeremy complained that we ask users to modify
/etc/sysconfig/docker-storage-setup  and we don't ship one. He prefers that
we ship an empty one with additional information so that it is easier for
users to find it and edit it.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>