### PR TITLE
docker-storage-setup: Default to using 40% of free space for data volume

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -74,7 +74,7 @@ The options below should be specified as values acceptable to 'lvextend -L':
 ROOT_SIZE: The size to which the root filesystem should be grown.
 
 DATA_SIZE: The desired size for the docker data LV.  Defaults to using
-           60% free space in the VG after the root LV and docker
+           40% free space in the VG after the root LV and docker
            metadata LV have been allocated/grown.
 
            DATA_SIZE can take values acceptable to "lvcreate -L" as

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -32,7 +32,7 @@ STORAGE_DRIVER=devicemapper
 # in syntax are acceptable.  If value does not contain "%" it is assumed
 # value is suitable for "lvcreate -L".
 #
-DATA_SIZE=60%FREE
+DATA_SIZE=40%FREE
 
 # Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
 # be suitable to be passed to --chunk-size option of lvconvert.


### PR DESCRIPTION
Fixes issue #67 

Some people complained that using 60% of free space might be a lot. Instead
start small and let the pool grow automatically. 

So drop the default data volume size to 40% of free space.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>