### PR TITLE
docker-storage-setup: Relax restriction on data size suffixes

### DIFF
--- a/libdss.sh
+++ b/libdss.sh
@@ -1,17 +1,27 @@
 #!/bin/bash
 # Library for common functions
 
-check_data_size_syntax() {
-  local data_size=$1
+# checks the size specifications acceptable to -L
+check_numeric_size_syntax() {
+  data_size=$1
 
   # if it is all numeric, it is valid as by default it will be MB.
   [[ $data_size =~ ^[[:digit:]]+$ ]] && return 0
 
-  # -L compatible syntax
-  if [[ $data_size != *%* ]]; then
-    # Numeric digits followed by valid suffix.
-    [[ $data_size =~ ^[[:digit:]]+[bBsSkKmMgGtTpPeE]$ ]] && return 0
-  fi
+  # Numeric digits followed by b or B. (byte specification)
+  [[ $data_size =~ ^[[:digit:]]+[bB]$ ]] && return 0
+
+  # Numeric digits followed by valid suffix. Will support both G and GB.
+  [[ $data_size =~ ^[[:digit:]]+[sSkKmMgGtTpPeE][bB]?$ ]] && return 0
+
+  # Numeric digits followed by valid suffix and ib. Ex. Gib or GiB.
+  [[ $data_size =~ ^[[:digit:]]+[sSkKmMgGtTpPeE]i[bB]$ ]] && return 0
+
+  return 1
+}
+
+check_data_size_syntax() {
+  local data_size=$1
 
   # For -l style options, we only support %FREE and %VG option. %PVS and
   # %ORIGIN does not seem to make much sense for this use case.
@@ -19,17 +29,7 @@ check_data_size_syntax() {
     return 0
   fi
 
-  return 1
-}
-
-check_min_data_size_syntax() {
-  local min_data_size=$1
-
-  # if it is all numeric, it is valid as by default it will be MB.
-  [[ $min_data_size =~ ^[[:digit:]]+$ ]] && return 0
-
-  # Numberic digits followed by valid suffix.
-  [[ $min_data_size =~ ^[[:digit:]]+[bBsSkKmMgGtTpPeE]$ ]] && return 0
-
+  # -L compatible syntax
+  check_numeric_size_syntax $data_size && return 0
   return 1
 }


### PR DESCRIPTION
Fixes issue #70 

Previously we were not doing any checks on DATA_SIZE suffixes and passing
everything to lvm directly. It turns out lvm just checks if things are
starting with valid suffix and anythign after that is acceptable. For
example -L 5GHello is acceptable and lvm will treat it as 5GiB.

Then with MIN_DATA_SIZE patch, we put limitations on suffixes. One could
use only one valid suffix character and nothing after that. For example,
only 5G is acceptable and 5GB and 5GiB are failing.

This is being seen as regression.

This patch allows now [bB] and i[bB] after the valid suffix. That is,
values of type 5G, 5GB, 5GiB are acceptable and all will be treated
as 5GiB.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>