### PR TITLE
docker-storage-setup: Error out if /usr/bin/growpart is not available

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -344,10 +344,13 @@ is_old_data_meta_mode() {
 }
 
 grow_root_pvs() {
-  [ -x "/usr/bin/growpart" ] || return 0
-
   # Grow root pvs only if user asked for it through config file.
   [ "$GROWPART" != "true" ] && return
+
+  if [ ! -x "/usr/bin/growpart" ];then
+    echo "GROWPART=true is specified and /usr/bin/growpart executable is not available. Install /usr/bin/growpart and try again."
+    return 1
+  fi
 
   # Note that growpart is only variable here because we may someday support
   # using separate partitions on the same disk.  Today we fail early in that


### PR DESCRIPTION
Fixes issue #78 

Right now if user wants to grow partitions and specifies GROWPART=true then
d-s-s will not fail even if /usr/bin/growpart is not available.

Hence, give an error message and exit is /usr/bin/growpart is not available
and user specified GROWPART=true.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>