### PR TITLE
Correct version check for Docker > 1.7

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -83,7 +83,7 @@ get_deferred_removal_string() {
 	[ -z "$minor" ] && return 0
 
 	# docker 1.7 onwards supports deferred device removal. Enable it.
-	if [ "$major" -ge "1" ] && [ "$minor" -ge "7" ];then
+	if [ $major -gt 1 ] ||  ([ $major -eq 1 ] && [ $minor -ge 7 ]);then
 		echo "--storage-opt dm.use_deferred_removal=true"
 	fi
 }


### PR DESCRIPTION
This line would have failed as soon as Docker `2.0` was released. Also de-quoted for numeric comparison (keeps consistent with rest of file)