### PR TITLE
Allow overlay to be used even if image is not using lvm

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -594,7 +594,8 @@ fi
 
 # Read mounts
 ROOT_DEV=$( awk '$2 ~ /^\/$/ && $1 !~ /rootfs/ { print $1 }' /proc/mounts )
-if ! ROOT_VG=$(lvs --noheadings -o vg_name $ROOT_DEV);then
+if ! ROOT_VG=$(lvs --noheadings -o vg_name $ROOT_DEV 2>/dev/null);then
+  echo "INFO: Volume group backing root filesystem could not be determined"
   ROOT_VG=
 else
   ROOT_VG=$(echo $ROOT_VG | sed -e 's/^ *//' -e 's/ *$//')

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -601,7 +601,10 @@ else
   ROOT_VG=$(echo $ROOT_VG | sed -e 's/^ *//' -e 's/ *$//')
 fi
 
-ROOT_PVS=$( pvs --noheadings -o pv_name,vg_name | awk "\$2 ~ /^$ROOT_VG\$/ { print \$1 }" )
+ROOT_PVS=
+if [ -n "$ROOT_VG" ];then
+  ROOT_PVS=$( pvs --noheadings -o pv_name,vg_name | awk "\$2 ~ /^$ROOT_VG\$/ { print \$1 }" )
+fi
 
 VG_EXISTS=
 if [ -z "$VG" ]; then


### PR DESCRIPTION
Right now we are checking early that either rootfs is backed by a volume group or user has specified a volume group using VG=. Otherwise script exits early thinking no progress can be made.

This was true when we only supported devicemapper storage driver. Now we also support overlay and overlay can still be configured even if a valid VG is not there.

Fix it.
