### PR TITLE
Set VG_EXISTS=1 after volume group creation

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -435,6 +435,7 @@ EOF
 create_extend_volume_group() {
   if [ -z "$VG_EXISTS" ]; then
     vgcreate $VG $PVS
+    VG_EXISTS=1
   else
     # TODO:
     #   * Error handling when PV is already part of a VG


### PR DESCRIPTION
Set VG_EXISTS=1 after volume group creation. Later code checks it to
make sure volume group exists otherwise code errors out.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>