### PR TITLE
Allow block device name as valid input to DEVS

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -417,7 +417,9 @@ check_block_devs() {
   local devs=$1
 
   for dev in ${devs}; do
-    if [ ! -b "$dev" ];then
+    # Looks like we allowed just device name (sda) as valid input. In
+    # such cases /dev/$dev should be a valid block device.
+    if [ ! -b "$dev" ] && [ ! -b "/dev/$dev" ];then
       Fatal "$dev is not a valid block device."
     fi
 


### PR DESCRIPTION
Looks like we allow just block device name as valid input. Say DEVS=sda.
Recent changes broke it as it expected input to be a full device path
name (/dev/sda). 

For now fix it by continuing to accept just device name as input and
prefix /dev/ internally. 

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>