### PR TITLE
Move Info() messages to STDERR

### DIFF
--- a/libdss.sh
+++ b/libdss.sh
@@ -3,7 +3,9 @@
 
 # echo info messages on stdout
 Info() {
-  echo "INFO: ${1}"
+  # stdout is used to pass back output from bash functions
+  #  so we use stderr
+  echo "INFO: ${1}" >&2
 }
 
 # echo error messages on stderr


### PR DESCRIPTION
docker-storage-setup.sh functions expect to return strings via STDOUT 
therefore Info() cannot report messages on that FD.

This patch moves Info() messages to STDERR.

Signed-off-by: Jhon Honce <jhonce@redhat.com>