### PR TITLE
Allow dm.fs to be overridden

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -29,6 +29,10 @@ STORAGE_DRIVER:
       and "". Empty string tells docker-storage-setup to not do
       any storage setup.
 
+EXTRA_DOCKER_STORAGE_OPTIONS:
+      A set of extra options that should be passed to the Docker
+      daemon.
+
 DEVS: A quoted, space-separated list of devices to be used.
       If a drive is partitioned and contains a ${dev}1 partition,
       that partition will be configured for use. Unpartitioned

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -4,6 +4,11 @@
 #
 STORAGE_DRIVER=devicemapper
 
+# A set of extra options that should be appended to the generated
+# DOCKER_STORAGE_OPTIONS string. These options will be passed to the Docker
+# daemon as-is and should be valid Docker storage options.
+# EXTRA_DOCKER_STORAGE_OPTIONS="--storage-opt dm.fs=ext4"
+
 # A quoted, space-separated list of devices to be used.  This currently
 # expects the devices to be unpartitioned drives.  If "VG" is not specified,
 # then use of the root disk's extra space is implied.


### PR DESCRIPTION
We're seeing some [bad behavior](https://github.com/docker/docker/issues/20707) when xfs is used and the underlying LV/VG/PV are completely full.  Experimentally, ext4 has better failure modes, so this commit allows setting the filesystem.