### PR TITLE
Introduce a helper to wait for a device

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -75,6 +75,14 @@ CHUNK_SIZE:
       Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
       be suitable to be passed to --chunk-size option of lvconvert.
 
+DEVICE_WAIT_TIMEOUT:
+           Specifies a device wait timeout value in seconds. In
+           certain cases required devices might not be immediately
+           available and docker-storage-setup might decide to wait for
+           it. This timeout specifies how long one should wait for the
+           device. Default is 60 seconds. One can disable the wait by
+           specifying a value of 0.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -71,3 +71,8 @@ POOL_AUTOEXTEND_THRESHOLD=60
 
 # Extend the pool by specified percentage when threshold is hit.
 POOL_AUTOEXTEND_PERCENT=20
+
+# Device wait timeout in seconds. This is generic timeout which can be used by
+# docker storage setup service to wait on various kind of block devices.
+# Setting a value of 0 can disable this wait.
+DEVICE_WAIT_TIMEOUT=60


### PR DESCRIPTION
Introduce an helper to wait for a device. Also make wait time configurable
using knob DEVICE_WAIT_TIMEOUT. Default value is 60 seconds. One can disable
wait by specifying DEVICE_WAIT_TIMEOUT=0.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>