### PR TITLE
[merged] Wait for thin pool

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -454,6 +454,18 @@ is_dev_part_of_vg() {
  return 1
 }
 
+# Check if passed in vg exists. Returns 0 if volume group exists.
+vg_exists() {
+  local check_vg=$1
+
+  for vg_name in $(vgs --noheadings -o vg_name); do
+    if [ "$vg_name" == "$VG" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 is_block_dev_partition() {
   local bdev=$1
 
@@ -753,12 +765,9 @@ if [ -z "$VG" ]; then
     VG_EXISTS=1
   fi
 else
-  for vg_name in $( vgs --noheadings -o vg_name ); do
-    if [ "$vg_name" == "$VG" ]; then
-      VG_EXISTS=1
-      break
-    fi
-  done
+  if vg_exists "$VG";then
+    VG_EXISTS=1
+  fi
 fi
 
 # If there is no volume group specified or no root volume group, there is


### PR DESCRIPTION
There are situations where it takes a while for thin pool to come up. In that case docker-storage-setup can exit pretty soon and docker fails saying thin pool is not there.

So if a thin pool is configured in /etc/sysconfig/docker-storage, wait for that thin pool to come up. That will block docker too till thin pool comes up.

We just committed the patches to wait for devices and this patch series re-uses it. So default wait time continues to be 60 seconds.

