### PR TITLE
Improve error message when thin pool wait times out

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -376,7 +376,7 @@ setup_lvm_thin_pool () {
   if [ -n "$tpool" ]; then
      Info "Found an already configured thin pool $tpool in ${DOCKER_STORAGE}"
      if ! wait_for_dev "$tpool"; then
-       Fatal "Already configured thin pool $tpool is not available. If thin pool is taking longer to activate, set DEVICE_WAIT_TIMEOUT to a higher value and retry"
+       Fatal "Already configured thin pool $tpool is not available. If thin pool exists and is taking longer to activate, set DEVICE_WAIT_TIMEOUT to a higher value and retry. If thin pool does not exist any more, remove ${DOCKER_STORAGE} and retry"
      fi
   fi
 


### PR DESCRIPTION
Fixes #112 

Thin pool wait can timeout for two reasons. First one is that thin pool
exists but it is taking longer to activate and second one is that thin
pool does not exist any more (user has deleted the thin pool but did not
remove /etc/sysconfig/docker-storage).

Current error message covers the first condition but does not say anything
about second possibility.

Improve error message so that a user can take appropriate action.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>