### PR TITLE
[merged] Recreate missing /etc/sysconfig/docker-storage file

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -405,6 +405,13 @@ setup_lvm_thin_pool () {
     check_docker_storage_metadata
     create_lvm_thin_pool
     write_storage_config_file
+  else
+    # At this point /etc/sysconfig/docker-storage file should exist. If user
+    # deleted this file accidently without deleting thin pool, recreate it.
+    if [ ! -f "$DOCKER_STORAGE" ];then
+      Info "$DOCKER_STORAGE file is missing. Recreating it."
+      write_storage_config_file
+    fi
   fi
 
   # Enable or disable automatic pool extension


### PR DESCRIPTION
Some users complained that if they delete /etc/sysconfig/docker-storage file
without deleting lvm thin pool, then they are forced to do full cleanup. That
is delete lvm thin pool, delete /var/lib/docker and restart docker.

This might not be necessarily required. If thin pool is still around, then
we should be able to recreate /etc/sysconfig/docker-storage. 

So this patch introduces this change. If thin pool is around but /etc/sysconfig/docker-storage is missing, recreate it.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>