### PR TITLE
Wipe newly created partitions

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -578,6 +578,11 @@ EOF
     if ! wait_for_dev ${dev}1; then
       Fatal "Partition device ${dev}1 is not available"
     fi
+    # Sometimes there is still a old filesystem signature where we
+    # have just created our new partition.  Pvcreate will find it and
+    # ask for confirmation to overwrite it.  So we wipe the new
+    # partition first.
+    wipefs -a ${dev}1
     pvcreate ${dev}1
     PVS="$PVS ${dev}1"
   done

--- a/tests/002-no-pvcreate-prompts-for-stale-fs-signatures
+++ b/tests/002-no-pvcreate-prompts-for-stale-fs-signatures
@@ -1,0 +1,66 @@
+# Checks that stale filesystem signatures on one of the devices do not
+# cause pvcreate to prompt.
+
+test_stale_fs_signature() {
+  local devs=$DEVS
+  local test_status
+  local testname=`basename "$0"`
+  local vg_name
+  local vg_name="dss-test-foo"
+
+  # Error out if any pre-existing volume group vg named dss-test-foo
+  for vg in $(vgs --noheadings -o vg_name); do
+    if [ "$vg" == "$vg_name" ]; then
+      echo "ERROR: $testname: Volume group $vg_name already exists."
+      return 1
+    fi
+  done
+
+  # Create config file
+  clean_config_files
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+DEVS="$devs"
+VG=$vg_name
+EOF
+
+  # Put a filesystem signature into the first block of the partition
+  # that docker-storage-setup will create, but don't leave any actual
+  # partition table on the device.
+  for d in $devs; do
+    wipefs -a $dev && udevadm settle
+    size=$(( $( awk "\$4 ~ /"$( basename $dev )"/ { print \$3 }" /proc/partitions ) * 2 - 2048 ))
+    cat <<EOF | sfdisk $dev
+unit: sectors
+
+${dev}1 : start=     2048, size=  ${size}, Id=8e
+EOF
+    mkfs.xfs ${dev}1 && udevadm settle
+    wipefs -a $dev && udevadm settle
+  done
+
+  # Run docker-storage-setup with stdin from /dev/null
+  $DSSBIN >> $LOGS 2>&1 </dev/null
+
+  # Test failed.
+  [ $? -ne 0 ] && return 1
+
+  test_status=1
+  # Make sure volume group $VG got created.
+  for vg in $(vgs --noheadings -o vg_name); do
+      if [ "$vg" == "$vg_name" ]; then
+      test_status=0
+      break
+    fi
+  done
+
+  # Do cleanup only in case of success
+  [ $test_status -eq 1 ] && return 1
+
+  vgremove -y $vg_name >> $LOGS 2>&1
+  remove_pvs "$devs"
+  remove_partitions "$devs"
+  clean_config_files
+  return $test_status
+}
+
+test_stale_fs_signature


### PR DESCRIPTION
This avoids a bogus prompt by pvcreate which would make non-interactive runs fail, such as during boot.
