### PR TITLE
[merged] Wipe Signature Related Cleanup

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -83,6 +83,14 @@ DEVICE_WAIT_TIMEOUT:
            device. Default is 60 seconds. One can disable the wait by
            specifying a value of 0.
 
+WIPE_SIGNATURES:
+      Wipe any signatures found on disk. Valid values are
+      true/false and default value is false. By default if any
+      signatures are found on disk operation is aborted. If this value
+      is set to true, then signatures will either be wiped or
+      overwritten as suitable. This also means that if there is any
+      data on disk, it will be lost.
+
 The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -76,3 +76,11 @@ POOL_AUTOEXTEND_PERCENT=20
 # docker storage setup service to wait on various kind of block devices.
 # Setting a value of 0 can disable this wait.
 DEVICE_WAIT_TIMEOUT=60
+
+# Wipe any signatures (partition, filesystem, lvm etc) found on disk.
+# This could mean wiping the signature explicitly or using force options
+# of various commands to wipe/overwrite signatures. By default signatures
+# are not wiped and user needs to wipe these. One can change default behavior
+# by setting WIPE_SIGNATURES=true. Be careful before using this option
+# as this means if there was any leftover data on disk, it will be lost.
+WIPE_SIGNATURES=false

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -630,7 +630,12 @@ create_disk_partitions() {
       dev=/dev/$dev
     fi
     create_partition $dev
-    pvcreate ${dev}1
+
+    # By now we have ownership of disk and we have checked there are no
+    # signatures on disk or signatures have been overridden. Don't care
+    # about any signatures found in the middle of disk after creating
+    # partition and use force option.
+    pvcreate -f ${dev}1
     PVS="$PVS ${dev}1"
   done
 }

--- a/tests/003-test-override-signature-wipes-existing-signatures.sh
+++ b/tests/003-test-override-signature-wipes-existing-signatures.sh
@@ -1,0 +1,67 @@
+source $SRCDIR/libtest.sh
+
+cleanup() {
+  local vg_name=$1
+  local devs=$2
+
+  vgremove -y $vg_name >> $LOGS 2>&1
+  remove_pvs "$devs"
+  remove_partitions "$devs"
+  clean_config_files
+  wipe_signatures "$devs"
+}
+
+test_override_signatures() {
+  local devs=$DEVS dev
+  local test_status
+  local testname=`basename "$0"`
+  local vg_name
+  local vg_name="dss-test-foo"
+
+ # Error out if any pre-existing volume group vg named dss-test-foo
+  for vg in $(vgs --noheadings -o vg_name); do
+    if [ "$vg" == "$vg_name" ]; then
+      echo "ERROR: $testname: Volume group $vg_name already exists."
+      return 1
+    fi
+  done
+
+  # Create config file
+  clean_config_files
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+DEVS="$devs"
+VG=$vg_name
+WIPE_SIGNATURES=true
+EOF
+
+  # create lvm signatures on disks
+  for dev in $devs; do
+    pvcreate -f $dev >> $LOGS 2>&1
+  done
+
+  test_status=1
+  # Run docker-storage-setup
+  $DSSBIN >> $LOGS 2>&1
+
+  # Test failed.
+  if [ $? -ne 0 ]; then
+    cleanup $vg_name $devs
+    return 1
+  fi
+
+  # Make sure volume group $VG got created.
+  for vg in $(vgs --noheadings -o vg_name); do
+    if [ "$vg" == "$vg_name" ]; then
+      test_status=0
+      break
+    fi
+  done
+
+  cleanup $vg_name $devs
+  return $test_status
+}
+
+# Create a disk with some signature, say lvm signature and make sure
+# override signature can override that, wipe signature and create thin
+# pool.
+test_override_signatures

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -21,3 +21,11 @@ remove_partitions() {
     parted ${dev} rm 1 >> $LOGS 2>&1
   done
 }
+
+# Wipe all signatures on devices
+wipe_signatures() {
+  local devs=$1
+  for dev in $devs; do
+    wipefs -a $dev >> $LOGS 2>&1
+  done
+}


### PR DESCRIPTION
Fixes #121 

This patch set does few things.

- Patch 1 and Patch2 are simple code reorganization and cleanup. No functionality change.

-  Reject a disk if it already contains signatures like LVM. Right now only exception is "dos" signatures. We allow that. And reason being that in the past we have allowed that. A disk might have dos signature without having any partition and we have accepted it. Don't want to create a regression scenario. We check for partitions anyway, so we know that disk is not partitioned.

-  Use pvcreate with option -f all the time. This means that if when we scan the disk for signatures, and if no objectionable signatures are there, then we own the disk and we will not worry about signatures which can become in visible later in the middle of disk. For example, after creating a partition if we
find a left over signature, we will not abort processing. By now we own the disk.

- Implement an option OVERRIDE_SIGNATURES which will allow one to wipe signature of disk even if one is present. By default it is set to false and that means we will reject disk if it contains a valid signature (except dos one).