### PR TITLE
[merged] Do not use pvcreate -f option

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -651,10 +651,13 @@ create_disk_partitions() {
     create_partition $dev
 
     # By now we have ownership of disk and we have checked there are no
-    # signatures on disk or signatures have been overridden. Don't care
+    # signatures on disk or signatures should be wiped. Don't care
     # about any signatures found in the middle of disk after creating
-    # partition and use force option.
-    pvcreate -f ${dev}1
+    # partition and wipe signatures if any are found.
+    if ! wipefs -a ${dev}1; then
+      Fatal "Failed to wipe signatures on device ${dev}1"
+    fi
+    pvcreate ${dev}1
     PVS="$PVS ${dev}1"
   done
 }


### PR DESCRIPTION
Do not use pvcreate -f option instead wipe signatures explicitly on the
partition device. Reason being that -f is not very well defined and 
tomorrow it can be overloaded to do more things. So it is safer to wipe
signatures explicitly and use pvcreate without -f.

At this point we own the disk. If there are any signatures on disk to
being with, we will not be here until and unless user asked to wipe
signatures using WIPE_SIGNATURES=true. We will not care for any signatures
found on disk after creating partition.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>