### PR TITLE
[merged] [WIP] Output more Info messages in wait_device()

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -129,11 +129,11 @@ wait_for_dev() {
   local devpath=$1
   local timeout=$DEVICE_WAIT_TIMEOUT
 
+  [ -b "$devpath" ] && return 0
+
   if [ -z "$DEVICE_WAIT_TIMEOUT" ] || [ "$DEVICE_WAIT_TIMEOUT" == "0" ];then
     return 0
   fi
-
-  [ -b "$devpath" ] && return 0
 
   while [ $timeout -gt 0 ]; do
     Info "Waiting for device $devpath to be available. Wait time remaining is $timeout seconds"

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -129,9 +129,13 @@ wait_for_dev() {
   local devpath=$1
   local timeout=$DEVICE_WAIT_TIMEOUT
 
-  [ -b "$devpath" ] && return 0
+  if [ -b "$devpath" ];then
+    Info "Device node $devpath exists."
+    return 0
+  fi
 
   if [ -z "$DEVICE_WAIT_TIMEOUT" ] || [ "$DEVICE_WAIT_TIMEOUT" == "0" ];then
+    Info "Not waiting for device $devpath as DEVICE_WAIT_TIMEOUT=${DEVICE_WAIT_TIMEOUT}."
     return 0
   fi
 
@@ -143,7 +147,10 @@ wait_for_dev() {
       sleep 5
     fi
     timeout=$((timeout-5))
-    [ -b "$devpath" ] && return 0
+    if [ -b "$devpath" ]; then
+      Info "Device node $devpath exists."
+      return 0
+    fi
   done
 
   Info "Timed out waiting for device $devpath"


### PR DESCRIPTION
We are facing quite a few issues w.r.t block device not being available before pvcreate is called or wipefs is called. wait_device() should have done its work. Output more info messages so that things can be proven one way or other.