### PR TITLE
[merged] Call udevadm settle after partition creation

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -632,6 +632,10 @@ EOF
 
   # Sometimes on slow storage it takes a while for partition device to
   # become available. Wait for device node to show up.
+  if ! udevadm settle;then
+    Fatal "udevadm settle after partition creation failed. Exiting."
+  fi
+
   if ! wait_for_dev ${dev}1; then
     Fatal "Partition device ${dev}1 is not available"
   fi


### PR DESCRIPTION
We were experiencing instances of pvcreate failing. It turned out that
partition device node was not created yet. So we added a busy wait loop
and made sure pvcreate is called after block device /dev/foo shows up.

Turns out this is not sufficient either. pvcreate can still fails for
variety of reason. Now it seems to be complaining that device is not
in /sys.

Recommendation is that until all udev rules have settled after device
creation, lvm can reject a device for variety of reasons. So idea is
that call "udevadm settle" after partition creation and make sure all
udev rules have run before procedding with pvcreate.

This patch call "udevadm settle" after partition creation.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>