### PR TITLE
Support for adding/removing physical volumes

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -9,6 +9,9 @@ docker\-storage\-setup - Grows the root filesystem and sets up storage for docke
 .PP
 \f[B]-h, --help\f[]
   Print usage statement
+\f[B]--reset\f[]
+  Reset your docker storage to init state.  This command is not sufficient to cleanup your
+  docker environment.  It is used by other tools like \f[B]atomic storage setup\f[]
 
 .SH EXAMPLES
 Run \f[B]docker-storage-setup\f[] after setting up your configuration in
@@ -129,6 +132,9 @@ DEVS=/dev/vdb
 DATA_SIZE=8GB
 
 .fi
+
+.SH "SEE ALSO"
+.BR atomic "(1)"
 
 .SH HISTORY
 

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -838,13 +838,13 @@ reset_storage() {
 }
 
 usage() {
-  cat >&2 <<-FOE
+  cat <<-FOE
     Usage: $1 [OPTIONS]
 
     Grows the root filesystem and sets up storage for docker
 
     Options:
-      -h, --help    Print help message
+     --help    Print help message
 FOE
 }
 
@@ -898,12 +898,16 @@ fi
 # Main Script
 
 if [ $# -gt 0 ]; then
-    if [ "$1" == "--reset" ]; then
+    if [ "$1" == "--help" ]; then
+        usage $(basename $0)
+        exit 0
+    elif [ "$1" == "--reset" ]; then
 	reset_storage
 	exit 0
+    else
+        usage $(basename $0) >&2
+        exit 1
     fi
-    usage $(basename $0)
-    exit 0
 fi
 
 # If there is no volume group specified or no root volume group, there is

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -868,6 +868,9 @@ usage() {
     Options:
      --help    Print help message
 
+     --add DEV ...
+               Add the given block devices to the storage pool
+
      --reset   Remove all images and reset storage
 
      --reset-and-reduce
@@ -929,6 +932,9 @@ if [ $# -gt 0 ]; then
     if [ "$1" == "--help" ]; then
         usage $(basename $0)
         exit 0
+    elif [ "$1" == "--add" ]; then
+        shift
+        DEVS=$@
     elif [ "$1" == "--reset" ]; then
 	reset_storage
 	exit 0

--- a/tests/004-test-devmapper-cleanup
+++ b/tests/004-test-devmapper-cleanup
@@ -1,0 +1,62 @@
+source $SRCDIR/libtest.sh
+
+cleanup() {
+  local test_status
+  local vg_name=$1
+  local devs=$2
+  $DSSBIN reset >> $LOGS 2>&1
+  test_status=0
+  if [ -e /etc/sysconfig/docker-storage ]; then
+     echo "  $DSSBIN reset Failed: $(basename testname)"
+     test_status=1
+  fi
+  clean_config_files
+  wipe_signatures "$devs"
+  return test_status
+}
+
+# Test DEVS= directive. Returns 0 on success and 1 on failure.
+test_devs() {
+  local devs=$DEVS
+  local test_status
+  local testname=`basename "$0"`
+  local vg_name
+  local vg_name="dss-test-foo"
+
+ # Error out if any pre-existing volume group vg named dss-test-foo
+  for vg in $(vgs --noheadings -o vg_name); do
+    if [ "$vg" == "$vg_name" ]; then
+      echo "ERROR: $testname: Volume group $vg_name already exists."
+      return 1
+    fi
+  done
+
+  # Create config file
+  clean_config_files
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+DEVS="$devs"
+VG=$vg_name
+EOF
+
+ # Run docker-storage-setup
+ $DSSBIN >> $LOGS 2>&1
+
+ # Test failed.
+ if [ $? -ne 0 ]; then
+    cleanup $vg_name $devs
+    return 1
+ fi
+
+ test_status=1
+ # Make sure volume group $VG got created.
+  for vg in $(vgs --noheadings -o vg_name); do
+    if [ "$vg" == "$vg_name" ]; then
+      test_status=0
+      break
+    fi
+  done
+
+  return cleanup $vg_name $devs
+}
+
+test_overlay

--- a/tests/005-test-overlayfs-cleanup
+++ b/tests/005-test-overlayfs-cleanup
@@ -1,0 +1,36 @@
+source $SRCDIR/libtest.sh
+
+cleanup() {
+  local vg_name=$1
+  local devs=$2
+  $DSSBIN --reset >> $LOGS 2>&1
+  test -e /etc/sysconfig/docker-storage && echo "ERROR: $0: Failed." && exit 1
+  clean_config_files
+  wipe_signatures "$devs"
+}
+
+# Test DEVS= directive. Returns 0 on success and 1 on failure.
+test_overlay() {
+  local testname=`basename "$0"`
+
+  # Create config file
+  clean_config_files
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+STORAGE_DRIVER=overlayfs
+EOF
+
+ # Run docker-storage-setup
+ $DSSBIN >> $LOGS 2>&1
+
+ # Test failed.
+ if [ $? -ne 0 ]; then
+    echo "ERROR: $testname: Failed."
+    cleanup
+    return 1
+ fi
+
+  cleanup
+  return 0
+}
+
+test_overlay


### PR DESCRIPTION
This sits on top of #128.  The idea is that this is wrapped by "atomic storage", just as "--reset".

This change is intended to support the Cockpit use cases describes here:

    https://github.com/cockpit-project/cockpit/wiki/Atomic:-Docker-Storage

This change allows adding disks to the storage pool, and removing them again.  Providing information about the storage pool will be supported by a later PR.

The `--add` option has been added to offer easy adding of disks, without having to edit /etc/sysconfig/docker-storage-setup.  The `--add` operation is a one-time, immediate change to the storage pool that either works or doesn't and does not have any effect beyond that.  For example, the block devices given to `--add` are not processed again the next time docker is started.

The ``--reset-and-reduce` option has been added to offer opportunistic removal of unused block devices from the pool, in a way that puts the devices back into a state that is acceptable to `--add`.

The user interface and API to these features is via the `atomic storage` command, see https://github.com/projectatomic/atomic/pull/373.
