### PR TITLE
[merged] test: Export TEST_DEVS instead of DEVS

### DIFF
--- a/tests/001-test-use-devs-to-create-thin-pool.sh
+++ b/tests/001-test-use-devs-to-create-thin-pool.sh
@@ -2,7 +2,7 @@ source $SRCDIR/libtest.sh
 
 # Test DEVS= directive. Returns 0 on success and 1 on failure.
 test_devs() {
-  local devs=$DEVS
+  local devs=$TEST_DEVS
   local test_status
   local testname=`basename "$0"`
   local vg_name

--- a/tests/002-test-reject-disk-with-lvm-signature.sh
+++ b/tests/002-test-reject-disk-with-lvm-signature.sh
@@ -3,7 +3,7 @@ source $SRCDIR/libtest.sh
 # Make sure a disk with lvm signature is rejected and is not overriden
 # by dss. Returns 0 on success and 1 on failure.
 test_lvm_sig() {
-  local devs=$DEVS dev
+  local devs=$TEST_DEVS dev
   local test_status
   local testname=`basename "$0"`
   local vg_name

--- a/tests/003-test-override-signature-wipes-existing-signatures.sh
+++ b/tests/003-test-override-signature-wipes-existing-signatures.sh
@@ -1,7 +1,7 @@
 source $SRCDIR/libtest.sh
 
 test_override_signatures() {
-  local devs=$DEVS dev
+  local devs=$TEST_DEVS dev
   local test_status
   local testname=`basename "$0"`
   local vg_name

--- a/tests/004-test-non-absolute-disk-name-support.sh
+++ b/tests/004-test-non-absolute-disk-name-support.sh
@@ -8,7 +8,7 @@ test_non_absolute_disk_name() {
 
   # Remove prefix /dev/ from disk names to test if non-absolute disk
   # names work.
-  for dev in $DEVS; do
+  for dev in $TEST_DEVS; do
     dev=${dev##/dev/}
     devs="$devs $dev"
   done
@@ -34,7 +34,7 @@ EOF
 
   # Test failed.
   if [ $? -ne 0 ]; then
-    cleanup $vg_name "$DEVS"
+    cleanup $vg_name "$TEST_DEVS"
     return 1
   fi
 
@@ -46,7 +46,7 @@ EOF
     fi
   done
 
-  cleanup $vg_name "$DEVS"
+  cleanup $vg_name "$TEST_DEVS"
   return $test_status
 }
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -120,7 +120,10 @@ run_tests() {
 export SRCDIR=`dirname $0`
 if [ -e $SRCDIR/dss-test-config ]; then
   source $SRCDIR/dss-test-config
-  export DEVS
+  # DEVS is used by dss as well. So exporting this can fail any tests which
+  # don't want to use DEVS. So export TEST_DEVS instead.
+  TEST_DEVS=$DEVS
+  export TEST_DEVS
 fi
 
 source $SRCDIR/libtest.sh


### PR DESCRIPTION
DEVS is parsed by docker-storage-setup. So if some test does not want to
use it, still it is used by the test and that can lead to unexpected
results. For example, when somebody tries to test overlay, DEVS is
still set and all the disks are unexpectedly added to volume group
backing root lv. That's not what overlay test wanted to test.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>