### PR TITLE
[merged] Add support for overlay2 graph driver

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -32,9 +32,9 @@ functionality to work properly.
 
 STORAGE_DRIVER:
       Specify a storage driver to be used with docker. Default
-      driver is "devicemapper". Other valid values are "overlay"
-      and "". Empty string tells docker-storage-setup to not do
-      any storage setup.
+      driver is "devicemapper". Other valid values are overlay,
+      overlay2 and "". Empty string tells docker-storage-setup to
+      not do any storage setup.
 
 EXTRA_DOCKER_STORAGE_OPTIONS:
       A set of extra options that should be passed to the Docker

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -1,6 +1,6 @@
 # Specify storage driver one wants to use with docker. Default is devicemapper.
-# Other possible options are overlay and "". Empty string means do not do
-# any storage setup.
+# Other possible options are overlay, overlay2 and "". Empty string means do
+# not do any storage setup.
 #
 STORAGE_DRIVER=devicemapper
 

--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -59,7 +59,7 @@ DATA_LV_NAME=$POOL_LV_NAME
 META_LV_NAME="${POOL_LV_NAME}meta"
 
 DOCKER_STORAGE="/etc/sysconfig/docker-storage"
-STORAGE_DRIVERS="devicemapper overlay"
+STORAGE_DRIVERS="devicemapper overlay overlay2"
 
 DOCKER_METADATA_DIR="/var/lib/docker"
 
@@ -186,6 +186,10 @@ get_overlay_config_options() {
   echo "DOCKER_STORAGE_OPTIONS=\"--storage-driver overlay ${EXTRA_DOCKER_STORAGE_OPTIONS}\""
 }
 
+get_overlay2_config_options() {
+  echo "DOCKER_STORAGE_OPTIONS=\"--storage-driver overlay2 ${EXTRA_DOCKER_STORAGE_OPTIONS}\""
+}
+
 write_storage_config_file () {
   local storage_options
 
@@ -195,6 +199,10 @@ write_storage_config_file () {
     fi
   elif [ "$STORAGE_DRIVER" == "overlay" ];then
     if ! storage_options=$(get_overlay_config_options); then
+      return 1
+    fi
+  elif [ "$STORAGE_DRIVER" == "overlay2" ];then
+    if ! storage_options=$(get_overlay2_config_options); then
       return 1
     fi
   fi
@@ -836,7 +844,7 @@ setup_storage() {
   # Set up lvm thin pool LV
   if [ "$STORAGE_DRIVER" == "devicemapper" ]; then
     setup_lvm_thin_pool
-  elif [ "$STORAGE_DRIVER" == "overlay" ];then
+  elif [[ "$STORAGE_DRIVER" == "overlay" || "$STORAGE_DRIVER" == "overlay2" ]];then
     setup_overlay
   fi
 }

--- a/tests/008-test-overlay2-setup-cleanup.sh
+++ b/tests/008-test-overlay2-setup-cleanup.sh
@@ -1,0 +1,47 @@
+source $SRCDIR/libtest.sh
+
+# Test "docker-storage-setup reset". Returns 0 on success and 1 on failure.
+test_reset_overlay2() {
+  local test_status=0
+  local testname=`basename "$0"`
+
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+STORAGE_DRIVER=overlay2
+EOF
+
+ # Run docker-storage-setup
+ $DSSBIN >> $LOGS 2>&1
+
+ # Test failed.
+ if [ $? -ne 0 ]; then
+    echo "ERROR: $testname: $DSSBIN Failed." >> $LOGS
+    clean_config_files
+    return 1
+ fi
+
+ if ! grep -q "overlay2" /etc/sysconfig/docker-storage; then
+    echo "ERROR: $testname: /etc/sysconfig/docker-storage does not have string overlay2." >> $LOGS
+    clean_config_files
+    return 1
+ fi
+
+ $DSSBIN --reset >> $LOGS 2>&1
+ if [ $? -ne 0 ]; then
+    # Test failed.
+    test_status=1
+ elif [ -e /etc/sysconfig/docker-storage ]; then
+    # Test failed.
+    test_status=1
+ fi
+  if [ ${test_status} -eq 1 ]; then
+    echo "ERROR: $testname: $DSSBIN --reset Failed." >> $LOGS
+  fi
+
+ clean_config_files
+ return $test_status
+}
+
+# Create a overlay2 docker backend and then make sure the
+# docker-storage-setup --reset
+# cleans it up properly.
+test_reset_overlay2


### PR DESCRIPTION
Right now docker-storage-setup does not allow specifying overlay2 as storage driver. Docker supports it. So start supporting overlay2 as well.