### PR TITLE
[merged] Detect that overlay2 is currently configured driver

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -783,7 +783,7 @@ get_existing_storage_driver() {
   [ -z "$options" ] && return 0
 
   # Check if -storage-driver <driver> is there.
-  if ! driver=$(echo $options | sed -n 's/.*\(--storage-driver [ ]*[a-z]*\).*/\1/p' | sed 's/--storage-driver *//');then
+  if ! driver=$(echo $options | sed -n 's/.*\(--storage-driver [ ]*[a-z0-9]*\).*/\1/p' | sed 's/--storage-driver *//');then
     return 1
   fi
 
@@ -794,7 +794,7 @@ get_existing_storage_driver() {
   fi
 
   # Check if -s <driver> is there.
-  if ! driver=$(echo $options | sed -n 's/.*\(-s [ ]*[a-z]*\).*/\1/p' | sed 's/-s *//');then
+  if ! driver=$(echo $options | sed -n 's/.*\(-s [ ]*[a-z][0-9]*\).*/\1/p' | sed 's/-s *//');then
     return 1
   fi
 


### PR DESCRIPTION
Right now even if overlay2 is currently configured driver, dss detects it
as overlay (and not overlay2).

This truncation happens due the way we have written regular expression
for matching pattern. It works for driver name as long as it contains
all small letters but not numbers. This patch fixes it.

Now currently configured driver is detected correctly and unnecessary
errors are avoided.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>