### PR TITLE
[merged] Do not try to manage thin pool not created by dss

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -413,7 +413,15 @@ setup_lvm_thin_pool () {
   tpool=`get_configured_thin_pool`
 
   if [ -n "$tpool" ]; then
+     local escaped_pool_lv_name=`echo $POOL_LV_NAME | sed 's/-/--/g'`
      Info "Found an already configured thin pool $tpool in ${DOCKER_STORAGE}"
+
+     # dss generated thin pool device name starts with /dev/mapper/ and
+     # ends with POOL_LV_NAME
+     if [[ "$tpool" != /dev/mapper/*${escaped_pool_lv_name} ]];then
+       Fatal "Thin pool ${tpool} does not see to be managed by docker-storage-setup. Exiting."
+     fi
+
      if ! wait_for_dev "$tpool"; then
        Fatal "Already configured thin pool $tpool is not available. If thin pool exists and is taking longer to activate, set DEVICE_WAIT_TIMEOUT to a higher value and retry. If thin pool does not exist any more, remove ${DOCKER_STORAGE} and retry"
      fi


### PR DESCRIPTION
Fixes #153 

In general /etc/sysconfig/docker-storage is managed by dss and user
should not edit it directly.

In the past there have been cases where this was not a strict
requirement. And looks like over upgrade we ran into a case
where a thin pool configured by user is not in same format
as dss expects it to be and various assumptions are broken
and errors happen.

Try to parse thin pool name and make sure it is in same
format as generated by dss and if it is not, exit early
and stop doing further processing.

This should allow user to continue with its setup.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>