### PR TITLE
[merged] Enable dm.use_deferred_deletion only if it is supported by the underlying kernel.

### DIFF
--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -12,6 +12,7 @@ Source1:        docker-storage-setup.service
 Source2:        docker-storage-setup.conf
 Source3:        docker-storage-setup-override.conf
 Source4:        libdss.sh
+Source5:        dss-child-read-write.sh
 
 BuildRequires:  pkgconfig(systemd)
 
@@ -39,6 +40,7 @@ install -d %{buildroot}%{_sysconfdir}/sysconfig/
 install -p -m 644 %{SOURCE3} %{buildroot}%{_sysconfdir}/sysconfig/docker-storage-setup
 install -d %{buildroot}/%{dsslibdir}
 install -p -m 755 %{SOURCE4} %{buildroot}/%{dsslibdir}/libdss.sh
+install -p -m 755 %{SOURCE5} %{buildroot}/%{dsslibdir}/dss-child-read-write
 
 %post
 %systemd_post %{name}.service

--- a/dss-child-read-write.sh
+++ b/dss-child-read-write.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This is a helper script which is called by docker-storage-setup.sh (d-s-s).
+# This script helps in providing synchronization primitives to d-s-s so that
+# d-s-s can determine whether deferred deletion is supported by the underlying
+# kernel or not.
+
+# $1 is named FIFO pipe.
+# This helper script will write to $1 to signal d-s-s that unshare has been completed successfully.
+echo "start" > $1
+# $2 is another named FIFO pipe.
+# This helper script will read from $2. The write for this pipe would come from d-s-s to indicate
+# that helper script can terminate now.
+read -t 10 n <>$2


### PR DESCRIPTION
Signed-off-by: Shishir Mahajan <shishir.mahajan@redhat.com>