### PR TITLE
[merged] systemd: Order After=cloud-init.service, not cloud-final

### DIFF
--- a/docker-storage-setup.service
+++ b/docker-storage-setup.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Docker Storage Setup
-After=cloud-final.service
+After=cloud-init.service
 Before=docker.service
 
 [Service]


### PR DESCRIPTION
See https://lists.fedoraproject.org/archives/list/cloud@lists.fedoraproject.org/thread/TRT6A5ZCCMEC2LNNAAEGUZYJV4P7MEB7/

At least in recent cloud-init, the previous situation created
an ordering cycle.  We really just want to run after the primary
configuration run, not after all scripts.

Should fix Fedora 25 Atomic Host startup.