### PR TITLE
[merged] Cleanup temporary mount point upon failure

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -136,18 +136,16 @@ should_enable_deferred_deletion() {
 platform_supports_deferred_deletion() {
         local deferred_deletion_supported=1
         trap cleanup_pipes EXIT
-        mkfifo $PIPE1
-        mkfifo $PIPE2
-        mount -o bind $TEMPDIR $TEMPDIR
         if [ ! -x "/usr/lib/docker-storage-setup/dss-child-read-write" ];then
            return 1
         fi
-        unshare -m /usr/lib/docker-storage-setup/dss-child-read-write $PIPE1 $PIPE2 &
+        mkfifo $PIPE1
+        mkfifo $PIPE2
+        unshare -m /usr/lib/docker-storage-setup/dss-child-read-write $PIPE1 $PIPE2 "$TEMPDIR" &
         read -t 10 n <>$PIPE1
         if [ "$n" != "start" ];then
 	   return 1
         fi
-        umount $TEMPDIR
         rmdir $TEMPDIR > /dev/null 2>&1
         deferred_deletion_supported=$?
         echo "finish" > $PIPE2

--- a/dss-child-read-write.sh
+++ b/dss-child-read-write.sh
@@ -6,8 +6,17 @@
 
 # $1 is named FIFO pipe.
 # This helper script will write to $1 to signal d-s-s that unshare has been completed successfully.
-echo "start" > $1
+
 # $2 is another named FIFO pipe.
 # This helper script will read from $2. The write for this pipe would come from d-s-s to indicate
 # that helper script can terminate now.
+
+# $3 is absolute path to a temp dir which child will bind mount. Parent will
+# later try to remove this dir.
+
+if ! mount -o bind $3 $3; then
+   echo "stop" > $1
+   exit 1
+fi
+echo "start" > $1
 read -t 10 n <>$2


### PR DESCRIPTION
Fixes #162 

platform_supports_deferred_deletion() mounts tempdir and then can exit
due to error conditions and never unmount that tempdir.  Do an unmount
during exit to do the cleanup.

Also make a error check little early. First do the check and then
create pipes and mount point.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>