### PR TITLE
Add dss-child-read-write to %files section

### DIFF
--- a/docker-storage-setup.spec
+++ b/docker-storage-setup.spec
@@ -57,6 +57,7 @@ install -p -m 755 %{SOURCE5} %{buildroot}/%{dsslibdir}/dss-child-read-write
 %{dsslibdir}/docker-storage-setup
 %config(noreplace) %{_sysconfdir}/sysconfig/docker-storage-setup
 %{dsslibdir}/libdss.sh
+%{dsslibdir}/dss-child-read-write
 
 %changelog
 * Thu Oct 16 2014 Andy Grimm <agrimm@redhat.com> - 0.0.1-2


### PR DESCRIPTION
Looks like we missed adding dss-child-read-write file to %files section
in spec file.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>