### PR TITLE
[merged] Follow device symlinks in DEVS

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -628,8 +628,16 @@ check_wipe_block_dev_sig() {
 canonicalize_block_devs() {
   local devs=$1 dev
   local devs_abs dev_abs
+  local dest_dev
 
   for dev in ${devs}; do
+    # If the device name is a symlink, follow it and use the target
+    if [ -h "$dev" ];then
+      if ! dest_dev=$(readlink -e $dev);then
+        Fatal "Failed to resolve symbolic link $dev"
+      fi
+      dev=$dest_dev
+    fi
     # Looks like we allowed just device name (sda) as valid input. In
     # such cases /dev/$dev should be a valid block device.
     dev_abs=$dev

--- a/tests/009-test-follow-symlinked-devices.sh
+++ b/tests/009-test-follow-symlinked-devices.sh
@@ -1,0 +1,48 @@
+source $SRCDIR/libtest.sh
+
+test_follow_symlinked_devices() {
+  local devs dev
+  local devlinks devlink
+  local test_status=1
+  local testname=`basename "$0"`
+  local vg_name="dss-test-foo"
+
+  # Create a symlink for a device and try to follow it
+  for dev in $TEST_DEVS; do
+    if [ ! -h $dev ]; then
+      devlink="/tmp/$(basename $dev)-test.$$"
+      ln -s $dev $devlink
+
+      dev=$devlink
+      devlinks="$devlinks $dev"
+    fi
+    devs="$devs $dev"
+    echo "Using symlinke devices: $dev -> $(readlink -e $dev)" >> $LOGS 
+  done
+
+  cat << EOF > /etc/sysconfig/docker-storage-setup
+DEVS="$devs"
+VG=$vg_name
+EOF
+  # Run docker-storage-setup
+  $DSSBIN >> $LOGS 2>&1
+
+  # Test failed.
+  if [ $? -ne 0 ]; then
+    cleanup_soft_links "$devlinks"
+    cleanup $vg_name "$TEST_DEVS"
+    return $test_status
+  fi
+
+  # Make sure volume group $VG got created.
+  if vg_exists "$vg_name"; then
+    test_status=0
+  fi
+
+  cleanup_soft_links "$devlinks"
+  cleanup $vg_name "$TEST_DEVS"
+  return $test_status
+}
+
+# Make sure symlinked disk names are supported.
+test_follow_symlinked_devices

--- a/tests/libtest.sh
+++ b/tests/libtest.sh
@@ -53,3 +53,11 @@ cleanup() {
   clean_config_files
   wipe_signatures "$devs"
 }
+
+cleanup_soft_links() {
+  local dev devs=$1
+
+  for dev in $devs; do
+    rm $dev
+  done
+}


### PR DESCRIPTION
This patch just checks if the content of DEVS is a symlink and if it is, follows it.

I'm adding this to avoid problems I've had with devices being renamed when they are reattached in openstack (but the problem is more general).