### PR TITLE
get_docker_root_dir: use realpath only when path is not empty.

### DIFF
--- a/docker-storage-setup.sh
+++ b/docker-storage-setup.sh
@@ -1049,6 +1049,9 @@ get_docker_root_dir(){
                 ;;
         esac
     done
+    if [ -z "$path" ];then
+      return
+    fi
     if ! DOCKER_ROOT_DIR=$(realpath -m $path);then
       Fatal "realpath failed on $path"
     fi


### PR DESCRIPTION
If a user has not specified `-g` or `--graph` for $DOCKER_ROOT_DIR
in `/etc/sysconfig/docker`, then $DOCKER_ROOT_DIR will default to
`/var/lib/docker`. In that case, $path will be empty, and `realpath`
would fail. This PR addresses that issue.

Signed-off-by: Shishir Mahajan <shishir.mahajan@redhat.com>