### PR TITLE
REMOVE ALL DOCKER_ references from man page and default config

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -1,7 +1,7 @@
 .TH "DOCKER-STORAGE-SETUP" "1" "NOVEMBER 2014" "Helper Script for Docker Storage Setup" ""
 .SH NAME
 .PP
-docker\-storage\-setup - Grows the root filesystem and sets up storage for docker.
+docker\-storage\-setup - Grows the root filesystem and sets up storage for container runtimes.
 .SH SYNOPSIS
 .PP
 \f[B]docker-storage-setup\f[] [OPTIONS]
@@ -11,11 +11,13 @@ docker\-storage\-setup - Grows the root filesystem and sets up storage for docke
   Print usage statement
 
 \f[B]--reset\f[]
-  Reset your docker storage to init state. Reset does not try to remove volume groups or try to remove any of the disks added previously.
-  
-Note: The
-\f[B]--reset\f[]
-command is not sufficient to cleanup your docker environment.  This option is used by other tools. (\f[B]atomic storage reset\f[])
+  Reset your container storage to init state. Reset does not remove
+  volume groups or remove any of the disks added previously.
+
+  Note: The \f[B]--reset\f[]
+command is not always sufficient to cleanup your
+  container runtime environment. Other tools (\f[B]atomic storage reset\f[])
+  use this command to cleanup all storage.
 
 .SH EXAMPLES
 Run \f[B]docker-storage-setup\f[] after setting up your configuration in
@@ -31,14 +33,16 @@ functionality to work properly.
 \f[B]Supported options for the configuration file\f[]:
 
 STORAGE_DRIVER:
-      Specify a storage driver to be used with docker. Default
-      driver is "devicemapper". Other valid values are overlay,
-      overlay2 and "". Empty string tells docker-storage-setup to
-      not do any storage setup.
+      Specify a storage driver to be used with container runtime.
+      Default: "devicemapper".
+      Valid values are overlay, overlay2 and "".
+      "" tells docker-storage-setup to not perform any storage setup.
 
-EXTRA_DOCKER_STORAGE_OPTIONS:
-      A set of extra options that should be passed to the Docker
-      daemon.
+EXTRA_STORAGE_OPTIONS:
+      A set of extra options that should be passed to the container
+      runtime daemon.
+      Note: EXTRA_STORAGE_OPTIONS replaces EXTRA_DOCKER_STORAGE_OPTIONS
+      which has been deprecated
 
 DEVS: A quoted, space-separated list of devices to be used.
       If a drive is partitioned and contains a ${dev}1 partition,
@@ -47,14 +51,13 @@ DEVS: A quoted, space-separated list of devices to be used.
       is not specified, then use of the root disk's extra space
       is implied.
 
-VG:   The volume group to use for docker storage.  Defaults to the
+VG:   The volume group to use for container storage.  Defaults to the
       volume group where the root filesystem resides.  If VG is
       specified and the volume group does not exist, it will be
       created (which requires that "DEVS" be nonempty, since we don't
       currently support putting a second partition on the root disk).
 
-      lvm2 version should be same or higher than lvm2-2.02.112 for lvm
-      thin pool functionality to work properly.
+Note: lvm2 needs to be lvm2-2.02.112 or later for lvm thin pool functionality to work properly.
 
 GROWPART:
       One can use this option to enable/disable growing of partition
@@ -79,16 +82,15 @@ POOL_AUTOEXTEND_PERCENT:
       pool size.
 
 CHUNK_SIZE:
-      Controls the chunk size/block size of thin pool. Value of CHUNK_SIZE
-      be suitable to be passed to --chunk-size option of lvconvert.
+      Controls the chunk size/block size of thin pool. CHUNK_SIZE value
+      must be suitable for passing to \f[B]lvconvert --chunk-size\f[].
 
 DEVICE_WAIT_TIMEOUT:
-           Specifies a device wait timeout value in seconds. In
-           certain cases required devices might not be immediately
-           available and docker-storage-setup might decide to wait for
-           it. This timeout specifies how long one should wait for the
-           device. Default is 60 seconds. One can disable the wait by
-           specifying a value of 0.
+      Specifies a device wait timeout value in seconds. In certain
+      cases required devices might not be immediately available and
+      docker-storage-setup might decide to wait for it. This timeout
+      specifies how long one should wait for the device.
+      Default is 60 seconds. 0 disables wait.
 
 WIPE_SIGNATURES:
       Wipe any signatures found on disk. Valid values are
@@ -98,43 +100,6 @@ WIPE_SIGNATURES:
       overwritten as suitable. This also means that if there is any
       data on disk, it will be lost.
 
-DOCKER_ROOT_VOLUME:
-      By default no new volume and filesystem will be setup
-      for docker root dir. Docker creates /var/lib/docker/ on
-      top of underlying filesystem for storing images and containers.
-
-      To carve out a separate logical volume for storing docker
-      images/containers/volumes data, set DOCKER_ROOT_VOLUME=yes
-
-      docker-storage-setup creates a logical volume with an XFS
-      filesystem mounted on docker root directory
-      (default: /var/lib/docker).
-
-      Note: DOCKER_ROOT_VOLUME is deprecated, and will be removed
-      soon. Use CONTAINER_ROOT_LV_MOUNT_PATH instead.
-
-      Note: A user cannot specify DOCKER_ROOT_VOLUME and
-      CONTAINER_ROOT_LV_MOUNT_PATH together. They are mutually exclusive
-      options.
-
-DOCKER_ROOT_VOLUME_SIZE:
-      Specify the desired size for docker root volume. It defaults
-      to 40% of all free space.
-
-      DOCKER_ROOT_VOLUME_SIZE can take values acceptable to
-      "lvcreate -L" as well as some values acceptable to to 
-      "lvcreate -l". If user intends to pass values acceptable 
-      to "lvcreate -l", then only those values which contains "%" 
-      in syntax are acceptable.  If value does not contain "%" it 
-      is assumed value is suitable for "lvcreate -L".
-
-      Note: If both STORAGE_DRIVER=devicemapper and
-      DOCKER_ROOT_VOLUME=yes is set, docker-storage-setup would set
-      up the thin pool for devicemapper first, followed by docker 
-      root volume. e.g if free space in the volume group is 10G, 
-      devicemapper thin pool size would be 4G (40% of 10G) and docker
-      root volume would be 2.4G (40% of 6G).
-
 CONTAINER_ROOT_LV_NAME:
      Name of the logical volume that will be mounted on
      CONTAINER_ROOT_LV_MOUNT_PATH. If a user is setting
@@ -142,12 +107,16 @@ CONTAINER_ROOT_LV_NAME:
      CONTAINER_ROOT_LV_NAME.
 
 CONTAINER_ROOT_LV_MOUNT_PATH:
-     Creates a logical volume named $CONTAINER_ROOT_LV_NAME
-     and mount it on $CONTAINER_ROOT_LV_MOUNT_PATH. By default
-     no new logical volume will be created. e.g. Specifying
-     CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers will carve
-     out a logical volume, create a filesystem on it and
-     mount it on /var/lib/containers.
+     Creates a logical volume named CONTAINER_ROOT_LV_NAME and mounts
+     it at the specified path. By default no new logical volume will
+     be created. For example:
+     \f[B]CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers\f[]
+     would carve out a logical volume, format it with an XFS filesystem
+     and mount it on /var/lib/containers. 
+
+     Note: DOCKER_ROOT_VOLUME is deprecated. Specifying
+     DOCKER_ROOT_VOLUME and CONTAINER_ROOT_LV_MOUNT_PATH
+     is not allowed.
 
 CONTAINER_ROOT_LV_SIZE:
      Specify the desired size for CONTAINER_ROOT_LV_MOUNT_PATH
@@ -172,30 +141,28 @@ The options below should be specified as values acceptable to 'lvextend -L':
 
 ROOT_SIZE: The size to which the root filesystem should be grown.
 
-DATA_SIZE: The desired size for the docker data LV.  Defaults to using
-           40% free space in the VG after the root LV and docker
-           metadata LV have been allocated/grown.
+DATA_SIZE: The desired size for the container runtime data LV.
+	Defaults: 40% free space in the VG after the root LV and container
+	runtime metadata LV have been allocated/grown.
 
-           DATA_SIZE can take values acceptable to "lvcreate -L" as
-           well as some values acceptable to "lvcreate -l". If user
-           intends to pass values acceptable to "lvcreate -l", then
-           only those values which contains "%" in syntax are
-           acceptable.  If value does not contain "%" it is assumed
-           value is suitable for "lvcreate -L".
+	DATA_SIZE can take values acceptable to "lvcreate -L" as well as
+	some values acceptable to "lvcreate -l". If user intends to pass
+	values acceptable to "lvcreate -l", then only those values which
+	contains "%" in syntax are acceptable.  If value does not contain
+	"%" it is assumed value is suitable for "lvcreate -L".
 
-MIN_DATA_SIZE:
-           Specifies the minimum size of the data volume. If sufficient
-           free space is not available, the pool creation will fail.
+MIN_DATA_SIZE: Specifies the minimum size of the data volume. If
+	sufficient free space is not available, the pool creation will
+	fail.
 
-           Value should be a number followed by a optional suffix.
-           "bBsSkKmMgGtTpPeE" are valid suffixes. If no suffix is
-           specified then value will be considered as megabyte unit.
+	Value should be a number followed by a optional suffix.
+	"bBsSkKmMgGtTpPeE" are valid suffixes. If no suffix is specified
+	then value will be considered as megabyte unit.
 
-           Both upper and lower case suffix represent same unit of
-           size. Use suffix B for Bytes, S for sectors as 512 bytes, K
-           for kibibytes (1024 bytes), M for mebibytes
-           (1024 kibibytes), G for gibibytes, T for tebibytes, P for
-           pebibytes and E for exbibytes.
+	Both upper and lower case suffix represent same unit of size.
+	Use suffix B for Bytes, S for sectors as 512 bytes, K for
+	kibibytes (1024 bytes), M for mebibytes (1024 kibibytes), G for
+	gibibytes, T for tebibytes, P for pebibytes and E for exbibytes.
 
 \f[B]Sample\f[]
 

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -1,12 +1,13 @@
-# Specify storage driver one wants to use with docker. Default is devicemapper.
+# Specify storage driver one wants to use with container runtimes.
+# Default is devicemapper.
 # Other possible options are overlay, overlay2 and "". Empty string means do
 # not do any storage setup.
 STORAGE_DRIVER=devicemapper
 
-# A set of extra options that should be appended to the generated
-# DOCKER_STORAGE_OPTIONS string. These options will be passed to the Docker
-# daemon as-is and should be valid Docker storage options.
-# EXTRA_DOCKER_STORAGE_OPTIONS="--storage-opt dm.fs=ext4"
+# Set extra options that will be appended to the generated STORAGE_OPTIONS
+# variable. These options will be passed to the container runtime daemon
+# as-is and should be valid container runtime storage options.
+# EXTRA_STORAGE_OPTIONS="--storage-opt dm.fs=ext4"
 
 # A quoted, space-separated list of devices to be used.  This currently
 # expects the devices to be unpartitioned drives.  If "VG" is not specified,
@@ -14,7 +15,7 @@ STORAGE_DRIVER=devicemapper
 #
 # DEVS=/dev/vdb
 
-# The volume group to use for docker storage.  Defaults to the
+# The volume group to use for container runtime storage.  Defaults to the
 # volume group where the root filesystem resides.  If VG is specified and the
 # volume group does not exist, it will be created (which requires that "DEVS"
 # be nonempty, since we don't currently support putting a second partition on
@@ -27,7 +28,7 @@ STORAGE_DRIVER=devicemapper
 #
 # ROOT_SIZE=8G
 
-# The desired size for the docker data LV.  It defaults using 60% of all
+# The desired size for the container runtime data LV.  Defaults using 60% of all
 # free space.
 #
 # DATA_SIZE can take values acceptable to "lvcreate -L" as well as some
@@ -72,7 +73,7 @@ POOL_AUTOEXTEND_THRESHOLD=60
 POOL_AUTOEXTEND_PERCENT=20
 
 # Device wait timeout in seconds. This is generic timeout which can be used by
-# docker storage setup service to wait on various kind of block devices.
+# container storage setup service to wait on various kind of block devices.
 # Setting a value of 0 can disable this wait.
 DEVICE_WAIT_TIMEOUT=60
 
@@ -84,53 +85,16 @@ DEVICE_WAIT_TIMEOUT=60
 # as this means if there was any leftover data on disk, it will be lost.
 WIPE_SIGNATURES=false
 
-# By default no new volume and filesystem will be setup for docker
-# root dir. Docker creates /var/lib/docker/ on top of underlying filesystem
-# for storing images and containers.
+# By default no new volume and filesystem will be setup for container runtime
+# root dir. For example the docker engin creates /var/lib/docker/ on top of
+# underlying filesystem for storing images and containers.
 #
-# To carve out a separate logical volume for storing docker
-# images/containers/volumes data, set DOCKER_ROOT_VOLUME=yes
-#
-# docker-storage-setup creates a logical volume with an XFS filesystem mounted
-# on docker root directory (default: /var/lib/docker).
-#
-# Note: DOCKER_ROOT_VOLUME is deprecated, and will be removed
-# soon. Use CONTAINER_ROOT_LV_MOUNT_PATH instead.
-#
-# Note: A user cannot specify DOCKER_ROOT_VOLUME and CONTAINER_ROOT_LV_MOUNT_PATH
-# together. They are mutually exclusive options.
-DOCKER_ROOT_VOLUME=no
-
-# Specify the desired size for docker root volume. It defaults to 40% of all
-# free space.
-#
-# DOCKER_ROOT_VOLUME_SIZE can take values acceptable to "lvcreate -L" as well
-# as some values acceptable to to "lvcreate -l". If user intends to pass
-# values acceptable to "lvcreate -l", then only those values which
-# contains "%" in syntax are acceptable.  If value does not contain "%" it
-# is assumed value is suitable for "lvcreate -L".
-#
-# Note: If both STORAGE_DRIVER=devicemapper and DOCKER_ROOT_VOLUME=yes is
-# set, docker-storage-setup would set up the thin pool for devicemapper
-# first, followed by docker root volume. e.g if free space in the volume 
-# group is 10G, devicemapper thin pool size would be 4G (40% of 10G)
-# and docker root volume would be 2.4G (40% of 6G).
-DOCKER_ROOT_VOLUME_SIZE=40%FREE
-
-# Name of the logical volume that will be mounted on CONTAINER_ROOT_LV_MOUNT_PATH.
-# If a user is setting CONTAINER_ROOT_LV_MOUNT_PATH, he/she must set CONTAINER_ROOT_LV_NAME
-# too.
+# Logical volume name that will be mounted on CONTAINER_ROOT_LV_MOUNT_PATH.
+# Setting CONTAINER_ROOT_LV_MOUNT_PATH requires CONTAINER_ROOT_LV_NAME be set
 # CONTAINER_ROOT_LV_NAME="container-root-lv"
 
-# Creates a logical volume named $CONTAINER_ROOT_LV_NAME and mount it on
-# $CONTAINER_ROOT_LV_MOUNT_PATH. By default no new logical volume will
-# be created. e.g. Specifying CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers
-# will carve out a logical volume, create a filesystem on it and mount
-# it on /var/lib/containers.
-# CONTAINER_ROOT_LV_MOUNT_PATH="/var/lib/containers"
-
-# Specify the desired size for CONTAINER_ROOT_LV_MOUNT_PATH root volume.
-# It defaults to 40% of all free space.
+# Specify the desired size for container root lv volume. It defaults to 40% of
+# all free space.
 #
 # CONTAINER_ROOT_LV_SIZE can take values acceptable to "lvcreate -L" as well
 # as some values acceptable to to "lvcreate -l". If user intends to pass
@@ -138,9 +102,16 @@ DOCKER_ROOT_VOLUME_SIZE=40%FREE
 # contains "%" in syntax are acceptable.  If value does not contain "%" it
 # is assumed value is suitable for "lvcreate -L".
 #
-# Note: If both STORAGE_DRIVER=devicemapper and CONTAINER_ROOT_LV_MOUNT_PATH is
+# Note: If both STORAGE_DRIVER=devicemapper and CONTAINER_ROOT_LV_NAME is
 # set, docker-storage-setup would set up the thin pool for devicemapper
-# first, followed by extra volume. e.g if free space in the volume
-# group is 10G, devicemapper thin pool size would be 4G (40% of 10G)
-# and extra volume would be 2.4G (40% of 6G).
+# first, followed by container runtime root volume. e.g if free space in the
+# volume group is 10G, devicemapper thin pool size would be 4G (40% of 10G)
+# and containe runtime root volume would be 2.4G (40% of 6G).
 CONTAINER_ROOT_LV_SIZE=40%FREE
+
+# Creates a logical volume named $CONTAINER_ROOT_LV_NAME and mount it on
+# $CONTAINER_ROOT_LV_MOUNT_PATH. By default no new logical volume will
+# be created. e.g. Specifying CONTAINER_ROOT_LV_MOUNT_PATH=/var/lib/containers
+# will carve out a logical volume, create a filesystem on it and mount
+# it on /var/lib/containers.
+# CONTAINER_ROOT_LV_MOUNT_PATH="/var/lib/containers"


### PR DESCRIPTION
This is part of the effort to convert docker-storage-setup to
container-storage-setup

First we want to remove all references to DOCKER in environment variables.