### PR TITLE
build: Do make install before running tests

### DIFF
--- a/.redhat-ci.yml
+++ b/.redhat-ci.yml
@@ -12,12 +12,11 @@ context: fedora/25/atomic
 
 required: true
 
-env:
-  DOCKER_STORAGE_SETUP: ./docker-storage-setup.sh
-
 tests:
   - systemctl stop docker
   - rm -rf /var/lib/docker
+  - ostree admin unlock
+  - make install
   - rm -f /etc/sysconfig/docker-storage-setup
   - rm -f /etc/sysconfig/docker-storage
   - if findmnt /dev/vdb; then umount /dev/vdb; fi


### PR DESCRIPTION
Do make install to make sure all config files have been installed at
proper place before tests run. Otherwise new PR can source old files
and not the new one and that can break tests.

Given new docker-storage-setup.sh will be installed in /usr/bin/, there
is no need to specify path of binary using environment variable. So
get rid of that.

Signed-off-by: Vivek Goyal <vgoyal@redhat.com>