### PR TITLE
Remove default thinpool name, user must specify it

### DIFF
--- a/docker-storage-setup.1
+++ b/docker-storage-setup.1
@@ -52,6 +52,12 @@ STORAGE_DRIVER:
       Valid values are overlay, overlay2 and "".
       "" tells docker-storage-setup to not perform any storage setup.
 
+CONTAINER_THINPOOL:
+      Specify the thinpool name for the lvm thinpool. This is required
+      when using the devicemapper STORAGE_DRIVER.  CONTAINER_THINPOOL
+      is logical volume name passed to \f[B]lvcreate\f[] when creating
+      the thin pool volume.
+
 EXTRA_STORAGE_OPTIONS:
       A set of extra options that should be passed to the container
       runtime daemon.

--- a/docker-storage-setup.conf
+++ b/docker-storage-setup.conf
@@ -15,6 +15,12 @@ STORAGE_DRIVER=devicemapper
 #
 # DEVS=/dev/vdb
 
+# Specify the thinpool name for the lvm thinpool, when using the
+# devicemapper STORAGE_DRIVER.  This is the logical volume name
+# for the newly created thin pool volume.
+#
+# CONTAINER_THINPOOL=container-thinpool
+
 # The volume group to use for container runtime storage.  Defaults to the
 # volume group where the root filesystem resides.  If VG is specified and the
 # volume group does not exist, it will be created (which requires that "DEVS"

--- a/tests/101-test-use-devs-to-create-thin-pool.sh
+++ b/tests/101-test-use-devs-to-create-thin-pool.sh
@@ -19,6 +19,7 @@ test_devs() {
   cat << EOF > $infile
 DEVS="$devs"
 VG=$vg_name
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
  # Run docker-storage-setup

--- a/tests/102-test-reject-disk-with-lvm-signature.sh
+++ b/tests/102-test-reject-disk-with-lvm-signature.sh
@@ -19,6 +19,7 @@ test_lvm_sig() {
   cat << EOF > ${infile}
 DEVS="$devs"
 VG=$vg_name
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
   # create lvm signatures on disks

--- a/tests/103-test-override-signature-wipes-existing-signatures.sh
+++ b/tests/103-test-override-signature-wipes-existing-signatures.sh
@@ -18,6 +18,7 @@ test_override_signatures() {
 DEVS="$devs"
 VG=$vg_name
 WIPE_SIGNATURES=true
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
   # create lvm signatures on disks

--- a/tests/104-test-non-absolute-disk-name-support.sh
+++ b/tests/104-test-non-absolute-disk-name-support.sh
@@ -24,6 +24,7 @@ test_non_absolute_disk_name() {
   cat << EOF > $infile
 DEVS="$devs"
 VG=$vg_name
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
   # Run docker-storage-setup

--- a/tests/105-test-devmapper-cleanup.sh
+++ b/tests/105-test-devmapper-cleanup.sh
@@ -18,6 +18,7 @@ test_reset_devmapper() {
   cat << EOF > $infile
 DEVS="$devs"
 VG=$vg_name
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
  # Run docker-storage-setup

--- a/tests/107-test-setting-extra-opts.sh
+++ b/tests/107-test-setting-extra-opts.sh
@@ -23,6 +23,7 @@ test_set_extra_opts() {
 DEVS="$devs"
 VG=$vg_name
 EXTRA_STORAGE_OPTIONS="$extra_options"
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
   # Run docker-storage-setup

--- a/tests/109-test-follow-symlinked-devices.sh
+++ b/tests/109-test-follow-symlinked-devices.sh
@@ -25,6 +25,7 @@ test_follow_symlinked_devices() {
   cat << EOF > $infile
 DEVS="$devs"
 VG=$vg_name
+CONTAINER_THINPOOL=container-thinpool
 EOF
   # Run docker-storage-setup
   $DSSBIN $infile $outfile >> $LOGS 2>&1

--- a/tests/110-test-fail-if-no-container-thinpool.sh
+++ b/tests/110-test-fail-if-no-container-thinpool.sh
@@ -1,0 +1,42 @@
+source $SRCDIR/libtest.sh
+
+test_fail_if_no_container_thinpool() {
+  local devs=$TEST_DEVS
+  local test_status=1
+  local testname=`basename "$0"`
+  local vg_name="dss-test-foo"
+  local infile=${WORKDIR}/container-storage-setup
+  local outfile=${WORKDIR}/container-storage
+  local tmplog=${WORKDIR}/tmplog
+  local errmsg="CONTAINER_THINPOOL must be defined for the devicemapper storage driver."
+  # Error out if any pre-existing volume group vg named dss-test-foo
+  if vg_exists "$vg_name"; then
+    echo "ERROR: $testname: Volume group $vg_name already exists." >> $LOGS
+    return $test_status
+  fi
+
+  cat << EOF > $infile
+DEVS="$devs"
+VG=$vg_name
+EOF
+  # Run docker-storage-setup
+  $DSSBIN $infile $outfile > $tmplog 2>&1
+  rc=$?
+  cat $tmplog >> $LOGS 2>&1
+
+  # Test failed.
+  if [ $rc -ne 0 ]; then
+      if grep --no-messages -q "$errmsg" $tmplog; then
+	  test_status=0
+      else
+	  echo "ERROR: $testname: $DSSBIN Failed for a reason other then \"$errmsg\"" >> $LOGS
+      fi
+  else
+      echo "ERROR: $testname: $DSSBIN Succeeded. Should have failed with CONTAINER_THINPOOL specified" >> $LOGS
+  fi
+  cleanup $vg_name "$devs" "$infile" "$outfile"
+  return $test_status
+}
+
+# Make sure command fails if no CONTAINER_THINPOOL is specified
+test_fail_if_no_container_thinpool

--- a/tests/112-test-use-devs-to-create-container-root-volume.sh
+++ b/tests/112-test-use-devs-to-create-container-root-volume.sh
@@ -24,6 +24,7 @@ DEVS="$devs"
 VG=$vg_name
 CONTAINER_ROOT_LV_NAME=$root_lv_name
 CONTAINER_ROOT_LV_MOUNT_PATH=$root_lv_mount_path
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
  # Run docker-storage-setup

--- a/tests/113-test-container-root-volume-cleanup.sh
+++ b/tests/113-test-container-root-volume-cleanup.sh
@@ -25,6 +25,7 @@ DEVS="$devs"
 VG=$vg_name
 CONTAINER_ROOT_LV_NAME=$root_lv_name
 CONTAINER_ROOT_LV_MOUNT_PATH=$root_lv_mount_path
+CONTAINER_THINPOOL=container-thinpool
 EOF
 
   # Run docker-storage-setup


### PR DESCRIPTION
Add new field CONTAINER_THINPOOL, which is required when using devicemapper.
We still will default to docker-pool if the user does not specify anything
for inputfile, but if user specifies input file, and they are using
devicemapper, they must specify CONTAINER_THINPOOL.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>